### PR TITLE
bump to v27.0.0-rc.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "27.0.0-rc.0"
+version = "27.0.0-rc.1"
 authors = ["shun suzuki <suzuki@hapis.k.u-tokyo.ac.jp>"]
 edition = "2021"
 license = "MIT"
@@ -69,13 +69,13 @@ approx = "0.5.1"
 ta = "0.5.0"
 csv = "1.3.0"
 seq-macro = "0.3.5"
-autd3 = { path = "./autd3", version = "27.0.0-rc.0" }
-autd3-driver = { path = "./autd3-driver", version = "27.0.0-rc.0" }
-autd3-derive = { path = "./autd3-derive", version = "27.0.0-rc.0" }
-autd3-gain-holo = { path = "./autd3-gain-holo", version = "27.0.0-rc.0" }
-autd3-link-simulator = { path = "./autd3-link-simulator", version = "27.0.0-rc.0" }
-autd3-link-soem = { path = "./autd3-link-soem", version = "27.0.0-rc.0" }
-autd3-link-twincat = { path = "./autd3-link-twincat", version = "27.0.0-rc.0" }
-autd3-modulation-audio-file = { path = "./autd3-modulation-audio-file", version = "27.0.0-rc.0" }
-autd3-firmware-emulator = { path = "./autd3-firmware-emulator", version = "27.0.0-rc.0" }
-autd3-protobuf = { path = "./autd3-protobuf", version = "27.0.0-rc.0" }
+autd3 = { path = "./autd3", version = "27.0.0-rc.1" }
+autd3-driver = { path = "./autd3-driver", version = "27.0.0-rc.1" }
+autd3-derive = { path = "./autd3-derive", version = "27.0.0-rc.1" }
+autd3-gain-holo = { path = "./autd3-gain-holo", version = "27.0.0-rc.1" }
+autd3-link-simulator = { path = "./autd3-link-simulator", version = "27.0.0-rc.1" }
+autd3-link-soem = { path = "./autd3-link-soem", version = "27.0.0-rc.1" }
+autd3-link-twincat = { path = "./autd3-link-twincat", version = "27.0.0-rc.1" }
+autd3-modulation-audio-file = { path = "./autd3-modulation-audio-file", version = "27.0.0-rc.1" }
+autd3-firmware-emulator = { path = "./autd3-firmware-emulator", version = "27.0.0-rc.1" }
+autd3-protobuf = { path = "./autd3-protobuf", version = "27.0.0-rc.1" }

--- a/autd3-derive/src/modulation.rs
+++ b/autd3-derive/src/modulation.rs
@@ -81,7 +81,7 @@ pub(crate) fn impl_mod_macro(input: syn::DeriveInput) -> TokenStream {
 
             fn operation_generator_with_segment(self, _: &Geometry, segment: Segment, transition_mode: Option<TransitionMode>) -> Result<Self::G, AUTDInternalError> {
                 Ok(Self::G {
-                    g: std::sync::Arc::new(self.calc()?),
+                    g: self.calc()?,
                     config: self.sampling_config(),
                     loop_behavior: self.loop_behavior(),
                     segment,

--- a/autd3-driver/src/datagram/modulation/cache.rs
+++ b/autd3-driver/src/datagram/modulation/cache.rs
@@ -3,6 +3,7 @@ use crate::derive::*;
 use std::{
     cell::{Ref, RefCell},
     rc::Rc,
+    sync::Arc,
 };
 
 use derive_more::Deref;
@@ -14,7 +15,7 @@ use derive_more::Deref;
 pub struct Cache<M: Modulation> {
     #[deref]
     m: M,
-    cache: Rc<RefCell<Vec<u8>>>,
+    cache: Rc<RefCell<Arc<Vec<u8>>>>,
     #[no_change]
     config: SamplingConfig,
     loop_behavior: LoopBehavior,
@@ -41,7 +42,7 @@ impl<M: Modulation> Cache<M> {
         Ok(())
     }
 
-    pub fn buffer(&self) -> Ref<'_, Vec<u8>> {
+    pub fn buffer(&self) -> Ref<'_, Arc<Vec<u8>>> {
         self.cache.borrow()
     }
 }
@@ -81,7 +82,7 @@ mod tests {
         let mut rng = rand::thread_rng();
 
         let m = TestModulation {
-            buf: vec![rng.gen(), rng.gen()],
+            buf: Arc::new(vec![rng.gen(), rng.gen()]),
             config: SamplingConfig::FREQ_4K,
             loop_behavior: LoopBehavior::infinite(),
         };
@@ -105,7 +106,7 @@ mod tests {
     impl Modulation for TestCacheModulation {
         fn calc(&self) -> ModulationCalcResult {
             self.calc_cnt.fetch_add(1, Ordering::Relaxed);
-            Ok(vec![0x00, 0x00])
+            Ok(Arc::new(vec![0x00, 0x00]))
         }
     }
 

--- a/autd3-driver/src/datagram/modulation/mod.rs
+++ b/autd3-driver/src/datagram/modulation/mod.rs
@@ -27,7 +27,7 @@ use itertools::Itertools;
 
 use super::DatagramST;
 
-pub type ModulationCalcResult = Result<Vec<u8>, AUTDInternalError>;
+pub type ModulationCalcResult = Result<Arc<Vec<u8>>, AUTDInternalError>;
 
 pub trait ModulationProperty {
     fn sampling_config(&self) -> SamplingConfig;
@@ -104,7 +104,7 @@ impl<'a> DatagramST for Box<dyn Modulation + Send + Sync + 'a> {
         transition_mode: Option<TransitionMode>,
     ) -> Result<Self::G, AUTDInternalError> {
         Ok(Self::G {
-            g: Arc::new(self.calc()?),
+            g: self.calc()?,
             config: self.sampling_config(),
             loop_behavior: self.loop_behavior(),
             segment,
@@ -192,7 +192,7 @@ mod tests {
 
     #[derive(Modulation, Clone, PartialEq, Debug)]
     pub struct TestModulation {
-        pub buf: Vec<u8>,
+        pub buf: Arc<Vec<u8>>,
         pub config: SamplingConfig,
         pub loop_behavior: LoopBehavior,
     }

--- a/autd3-driver/src/datagram/modulation/mod.rs
+++ b/autd3-driver/src/datagram/modulation/mod.rs
@@ -170,7 +170,7 @@ mod capi {
 
     impl Modulation for NullModulation {
         fn calc(&self) -> ModulationCalcResult {
-            Ok(vec![])
+            Ok(Arc::new(vec![]))
         }
     }
 

--- a/autd3-driver/src/lib.rs
+++ b/autd3-driver/src/lib.rs
@@ -33,6 +33,7 @@ pub mod derive {
     pub use autd3_derive::{Builder, Gain, Modulation};
     pub use itertools::Itertools;
     pub use std::collections::HashMap;
+    pub use std::sync::Arc;
     pub use tracing;
     pub use tynm;
 }

--- a/autd3-firmware-emulator/tests/op/clear.rs
+++ b/autd3-firmware-emulator/tests/op/clear.rs
@@ -22,7 +22,7 @@ struct TestMod {
 
 impl Modulation for TestMod {
     fn calc(&self) -> ModulationCalcResult {
-        Ok(vec![u8::MIN; 100])
+        Ok(Arc::new(vec![u8::MIN; 100]))
     }
 }
 

--- a/autd3-firmware-emulator/tests/op/modulation.rs
+++ b/autd3-firmware-emulator/tests/op/modulation.rs
@@ -23,7 +23,7 @@ use crate::{create_geometry, send};
 
 #[derive(Modulation)]
 pub struct TestModulation {
-    pub buf: Vec<u8>,
+    pub buf: Arc<Vec<u8>>,
     pub config: SamplingConfig,
     pub loop_behavior: LoopBehavior,
 }
@@ -96,7 +96,7 @@ fn send_mod(
         SILENCER_STEPS_INTENSITY_DEFAULT.max(SILENCER_STEPS_PHASE_DEFAULT) as u16..=u16::MAX,
     );
     let d = TestModulation {
-        buf: m.clone(),
+        buf: Arc::new(m.clone()),
         config: SamplingConfig::new(NonZeroU16::new(freq_div).unwrap()),
         loop_behavior,
     }
@@ -127,7 +127,7 @@ fn swap_mod_segmemt() -> anyhow::Result<()> {
     let m: Vec<_> = (0..MOD_BUF_SIZE_MIN).map(|_| 0x00).collect();
     let freq_div = SILENCER_STEPS_INTENSITY_DEFAULT.max(SILENCER_STEPS_PHASE_DEFAULT) as u16;
     let d = TestModulation {
-        buf: m.clone(),
+        buf: Arc::new(m.clone()),
         config: SamplingConfig::new(NonZeroU16::new(freq_div).unwrap()),
         loop_behavior: LoopBehavior::infinite(),
     }
@@ -152,7 +152,7 @@ fn mod_freq_div_too_small() -> anyhow::Result<()> {
 
     {
         let d = TestModulation {
-            buf: (0..2).map(|_| u8::MAX).collect(),
+            buf: Arc::new((0..2).map(|_| u8::MAX).collect()),
             config: SamplingConfig::new(NonZeroU16::new(1).unwrap()),
             loop_behavior: LoopBehavior::infinite(),
         }
@@ -166,7 +166,7 @@ fn mod_freq_div_too_small() -> anyhow::Result<()> {
 
     {
         let d = TestModulation {
-            buf: (0..2).map(|_| u8::MAX).collect(),
+            buf: Arc::new((0..2).map(|_| u8::MAX).collect()),
             config: SamplingConfig::new(NonZeroU16::MAX),
             loop_behavior: LoopBehavior::infinite(),
         }
@@ -180,7 +180,7 @@ fn mod_freq_div_too_small() -> anyhow::Result<()> {
         assert_eq!(Ok(()), send(&mut cpu, d, &geometry, &mut tx));
 
         let d = TestModulation {
-            buf: (0..2).map(|_| u8::MAX).collect(),
+            buf: Arc::new((0..2).map(|_| u8::MAX).collect()),
             config: SamplingConfig::new(
                 NonZeroU16::new(SILENCER_STEPS_PHASE_DEFAULT as _).unwrap(),
             ),
@@ -215,7 +215,7 @@ fn send_mod_invalid_transition_mode() -> anyhow::Result<()> {
     // segment 0 to 0
     {
         let d = TestModulation {
-            buf: (0..2).map(|_| u8::MAX).collect(),
+            buf: Arc::new((0..2).map(|_| u8::MAX).collect()),
             config: SamplingConfig::FREQ_4K,
             loop_behavior: LoopBehavior::infinite(),
         }
@@ -229,7 +229,7 @@ fn send_mod_invalid_transition_mode() -> anyhow::Result<()> {
     // segment 0 to 1 immidiate
     {
         let d = TestModulation {
-            buf: (0..2).map(|_| u8::MAX).collect(),
+            buf: Arc::new((0..2).map(|_| u8::MAX).collect()),
             config: SamplingConfig::FREQ_4K,
             loop_behavior: LoopBehavior::once(),
         }
@@ -243,7 +243,7 @@ fn send_mod_invalid_transition_mode() -> anyhow::Result<()> {
     // Infinite but SyncIdx
     {
         let d = TestModulation {
-            buf: (0..2).map(|_| u8::MAX).collect(),
+            buf: Arc::new((0..2).map(|_| u8::MAX).collect()),
             config: SamplingConfig::FREQ_4K,
             loop_behavior: LoopBehavior::infinite(),
         }
@@ -277,7 +277,7 @@ fn test_miss_transition_time(
 
     let transition_mode = TransitionMode::SysTime(DcSysTime::from_utc(transition_time).unwrap());
     let d = TestModulation {
-        buf: (0..2).map(|_| u8::MAX).collect(),
+        buf: Arc::new((0..2).map(|_| u8::MAX).collect()),
         config: SamplingConfig::FREQ_4K,
         loop_behavior: LoopBehavior::once(),
     }

--- a/autd3-firmware-emulator/tests/op/reads_fpga_state.rs
+++ b/autd3-firmware-emulator/tests/op/reads_fpga_state.rs
@@ -1,4 +1,4 @@
-use std::num::NonZeroU16;
+use std::{num::NonZeroU16, sync::Arc};
 
 use autd3_driver::{
     datagram::*,
@@ -52,7 +52,7 @@ fn send_reads_fpga_state() -> anyhow::Result<()> {
 
     {
         let d = TestModulation {
-            buf: (0..2).map(|_| u8::MAX).collect(),
+            buf: Arc::new((0..2).map(|_| u8::MAX).collect()),
             config: SamplingConfig::FREQ_4K,
             loop_behavior: LoopBehavior::infinite(),
         }

--- a/autd3-firmware-emulator/tests/op/silener.rs
+++ b/autd3-firmware-emulator/tests/op/silener.rs
@@ -123,6 +123,8 @@ fn silencer_completetion_steps_too_large_mod(
     #[case] expect: Result<(), AUTDInternalError>,
     #[case] steps_intensity: u32,
 ) -> anyhow::Result<()> {
+    use std::sync::Arc;
+
     use crate::op::modulation::TestModulation;
 
     let geometry = create_geometry(1);
@@ -135,7 +137,7 @@ fn silencer_completetion_steps_too_large_mod(
     // Send modulation
     {
         let d = TestModulation {
-            buf: (0..2).map(|_| u8::MAX).collect(),
+            buf: Arc::new((0..2).map(|_| u8::MAX).collect()),
             config: SamplingConfig::FREQ_40K,
             loop_behavior: LoopBehavior::infinite(),
         }

--- a/autd3-modulation-audio-file/src/csv.rs
+++ b/autd3-modulation-audio-file/src/csv.rs
@@ -73,7 +73,7 @@ impl Csv {
 
 impl Modulation for Csv {
     fn calc(&self) -> ModulationCalcResult {
-        Ok(self.read_buf()?)
+        Ok(Arc::new(self.read_buf()?))
     }
 
     #[tracing::instrument(level = "debug", skip(_geometry))]
@@ -99,9 +99,9 @@ mod tests {
 
     #[rstest::rstest]
     #[test]
-    #[case(Ok(vec![0xFF, 0x7F, 0x00]), vec![0xFF, 0x7F, 0x00], 4000 * Hz)]
+    #[case(Ok(Arc::new(vec![0xFF, 0x7F, 0x00])), vec![0xFF, 0x7F, 0x00], 4000 * Hz)]
     fn new(
-        #[case] expect: Result<Vec<u8>, AUTDInternalError>,
+        #[case] expect: ModulationCalcResult,
         #[case] data: Vec<u8>,
         #[case] sample_rate: Freq<u32>,
     ) -> anyhow::Result<()> {
@@ -117,9 +117,9 @@ mod tests {
 
     #[rstest::rstest]
     #[test]
-    #[case(Ok(vec![0xFF, 0x7F, 0x00]), vec![0xFF, 0x7F, 0x00], 4000.000001 * Hz)]
+    #[case(Ok(Arc::new(vec![0xFF, 0x7F, 0x00])), vec![0xFF, 0x7F, 0x00], 4000.000001 * Hz)]
     fn new_nearest(
-        #[case] expect: Result<Vec<u8>, AUTDInternalError>,
+        #[case] expect: ModulationCalcResult,
         #[case] data: Vec<u8>,
         #[case] sample_rate: Freq<f32>,
     ) -> anyhow::Result<()> {

--- a/autd3-modulation-audio-file/src/rawpcm.rs
+++ b/autd3-modulation-audio-file/src/rawpcm.rs
@@ -53,7 +53,7 @@ impl RawPCM {
 
 impl Modulation for RawPCM {
     fn calc(&self) -> ModulationCalcResult {
-        Ok(self.read_buf()?)
+        Ok(Arc::new(self.read_buf()?))
     }
 
     #[tracing::instrument(level = "debug", skip(_geometry))]
@@ -79,9 +79,9 @@ mod tests {
 
     #[rstest::rstest]
     #[test]
-    #[case(Ok(vec![0xFF, 0x7F, 0x00]), vec![0xFF, 0x7F, 0x00], 4000 * Hz)]
+    #[case(Ok(Arc::new(vec![0xFF, 0x7F, 0x00])), vec![0xFF, 0x7F, 0x00], 4000 * Hz)]
     fn new(
-        #[case] expect: Result<Vec<u8>, AUTDInternalError>,
+        #[case] expect: ModulationCalcResult,
         #[case] data: Vec<u8>,
         #[case] sample_rate: Freq<u32>,
     ) -> anyhow::Result<()> {
@@ -97,9 +97,9 @@ mod tests {
 
     #[rstest::rstest]
     #[test]
-    #[case(Ok(vec![0xFF, 0x7F, 0x00]), vec![0xFF, 0x7F, 0x00], 4000.000001 * Hz)]
+    #[case(Ok(Arc::new(vec![0xFF, 0x7F, 0x00])), vec![0xFF, 0x7F, 0x00], 4000.000001 * Hz)]
     fn new_nearest(
-        #[case] expect: Result<Vec<u8>, AUTDInternalError>,
+        #[case] expect: ModulationCalcResult,
         #[case] data: Vec<u8>,
         #[case] sample_rate: Freq<f32>,
     ) -> anyhow::Result<()> {

--- a/autd3-modulation-audio-file/src/wav.rs
+++ b/autd3-modulation-audio-file/src/wav.rs
@@ -73,7 +73,7 @@ impl Wav {
 impl Modulation for Wav {
     #[allow(clippy::unnecessary_cast)]
     fn calc(&self) -> ModulationCalcResult {
-        Ok(self.read_buf()?)
+        Ok(Arc::new(self.read_buf()?))
     }
 
     // GRCOV_EXCL_START
@@ -180,7 +180,7 @@ mod tests {
         let path = dir.path().join("tmp.wav");
         create_wav(&path, spec, data)?;
         let m = Wav::new(&path)?;
-        assert_eq!(Ok(expect), m.calc());
+        assert_eq!(Ok(Arc::new(expect)), m.calc());
 
         Ok(())
     }

--- a/autd3-protobuf/src/traits/autd3/modulation/sine/nearest.rs
+++ b/autd3-protobuf/src/traits/autd3/modulation/sine/nearest.rs
@@ -31,8 +31,7 @@ impl FromMessage<SineNearest>
     for autd3::modulation::Sine<autd3::modulation::sampling_mode::NearestFreq>
 {
     fn from_msg(msg: &SineNearest) -> Result<Self, AUTDProtoBufError> {
-        let mut sine =
-            autd3::modulation::Sine::from_freq_nearest(msg.freq * autd3_driver::defined::Hz);
+        let mut sine = autd3::modulation::Sine::new_nearest(msg.freq * autd3_driver::defined::Hz);
         if let Some(intensity) = msg.intensity {
             sine = sine.with_intensity(intensity as _);
         }
@@ -62,7 +61,7 @@ mod tests {
     fn test_sine() {
         let mut rng = rand::thread_rng();
 
-        let m = autd3::modulation::Sine::from_freq_nearest(rng.gen::<f32>() * Hz)
+        let m = autd3::modulation::Sine::new_nearest(rng.gen::<f32>() * Hz)
             .with_intensity(rng.gen())
             .with_offset(rng.gen())
             .with_phase(rng.gen::<f32>() * rad);

--- a/autd3-protobuf/src/traits/autd3/modulation/square/nearest.rs
+++ b/autd3-protobuf/src/traits/autd3/modulation/square/nearest.rs
@@ -32,7 +32,7 @@ impl FromMessage<SquareNearest>
 {
     fn from_msg(msg: &SquareNearest) -> Result<Self, AUTDProtoBufError> {
         let mut square =
-            autd3::modulation::Square::from_freq_nearest(msg.freq * autd3_driver::defined::Hz);
+            autd3::modulation::Square::new_nearest(msg.freq * autd3_driver::defined::Hz);
         if let Some(high) = msg.high {
             square = square.with_high(high as _);
         }
@@ -62,7 +62,7 @@ mod tests {
     fn test_square() {
         let mut rng = rand::thread_rng();
 
-        let m = autd3::modulation::Square::from_freq_nearest(rng.gen::<f32>() * Hz)
+        let m = autd3::modulation::Square::new_nearest(rng.gen::<f32>() * Hz)
             .with_high(rng.gen())
             .with_low(rng.gen())
             .with_duty(rng.gen());

--- a/autd3/src/controller/builder.rs
+++ b/autd3/src/controller/builder.rs
@@ -53,7 +53,7 @@ impl ControllerBuilder {
         timeout: Duration,
     ) -> Result<Controller<B::L>, AUTDError> {
         let geometry = Geometry::new(self.devices);
-        Ok(Controller {
+        Controller {
             link: link_builder.open(&geometry).await?,
             tx_buf: TxDatagram::new(geometry.num_devices()),
             rx_buf: vec![RxMessage::new(0, 0); geometry.num_devices()],
@@ -65,6 +65,6 @@ impl ControllerBuilder {
             timer_resolution: self.timer_resolution,
         }
         .open_impl(timeout)
-        .await?)
+        .await // GRCOV_EXCL_LINE
     }
 }

--- a/autd3/src/controller/group.rs
+++ b/autd3/src/controller/group.rs
@@ -178,7 +178,7 @@ mod tests {
         );
 
         assert_eq!(
-            Sine::new(150. * Hz).calc()?,
+            *Sine::new(150. * Hz).calc()?,
             autd.link[3].fpga().modulation(Segment::S0)
         );
         assert_eq!(

--- a/autd3/src/controller/mod.rs
+++ b/autd3/src/controller/mod.rs
@@ -301,7 +301,7 @@ mod tests {
 
         autd.geometry().iter().try_for_each(|dev| {
             assert_eq!(
-                Sine::new(150. * Hz).calc()?,
+                *Sine::new(150. * Hz).calc()?,
                 autd.link[dev.idx()].fpga().modulation(Segment::S0)
             );
             let f = Uniform::new(EmitIntensity::new(0x80)).calc(&autd.geometry)?(dev);

--- a/autd3/src/controller/mod.rs
+++ b/autd3/src/controller/mod.rs
@@ -104,16 +104,15 @@ impl<L: Link> Controller<L> {
     }
 
     #[tracing::instrument(skip(self))]
-    pub(crate) async fn open_impl(&mut self, timeout: Duration) -> Result<(), AUTDError> {
+    pub(crate) async fn open_impl(mut self, timeout: Duration) -> Result<Self, AUTDError> {
         #[cfg(target_os = "windows")]
         unsafe {
             tracing::debug!("Set timer resulution: {:?}", self.timer_resolution);
             windows::Win32::Media::timeBeginPeriod(self.timer_resolution.get());
         }
-
         self.send((Clear::new(), Synchronize::new()).with_timeout(timeout))
             .await?; // GRCOV_EXCL_LINE
-        Ok(())
+        Ok(self)
     }
 
     pub async fn close(&mut self) -> Result<(), AUTDError> {

--- a/autd3/src/datagram/gain/bessel.rs
+++ b/autd3/src/datagram/gain/bessel.rs
@@ -51,7 +51,7 @@ impl Gain for Bessel {
             let wavenumber = dev.wavenumber();
             move |tr| {
                 let r = rot * (tr.position() - pos);
-                let dist = theta.sin() * (r.x * r.x + r.y * r.y).sqrt() - theta.cos() * r.z;
+                let dist = theta.sin() * r.xy().norm() - theta.cos() * r.z;
                 (
                     Phase::from(-dist * wavenumber * rad) + phase_offset,
                     intensity,

--- a/autd3/src/datagram/gain/custom.rs
+++ b/autd3/src/datagram/gain/custom.rs
@@ -27,8 +27,7 @@ impl<
     > Gain for Custom<D, FT, F>
 {
     fn calc(&self, _geometry: &Geometry) -> GainCalcResult {
-        let f = &self.f;
-        Ok(Self::transform(f))
+        Ok(Self::transform(&self.f))
     }
 
     #[tracing::instrument(skip(self, _geometry))]

--- a/autd3/src/datagram/modulation/custom.rs
+++ b/autd3/src/datagram/modulation/custom.rs
@@ -2,7 +2,7 @@ use autd3_driver::derive::*;
 
 #[derive(Modulation, Clone, PartialEq, Debug)]
 pub struct Custom {
-    buffer: Vec<u8>,
+    buffer: Arc<Vec<u8>>,
     #[no_change]
     config: SamplingConfig,
     loop_behavior: LoopBehavior,
@@ -10,7 +10,7 @@ pub struct Custom {
 
 impl Custom {
     pub fn new(
-        buffer: Vec<u8>,
+        buffer: Arc<Vec<u8>>,
         config: impl IntoSamplingConfig,
     ) -> Result<Self, AUTDInternalError> {
         Ok(Self {
@@ -20,7 +20,7 @@ impl Custom {
         })
     }
 
-    pub fn new_nearest(buffer: Vec<u8>, config: impl IntoSamplingConfigNearest) -> Self {
+    pub fn new_nearest(buffer: Arc<Vec<u8>>, config: impl IntoSamplingConfigNearest) -> Self {
         Self {
             buffer,
             config: config.into_sampling_config_nearest(),
@@ -52,7 +52,7 @@ mod tests {
     fn new() -> anyhow::Result<()> {
         let mut rng = rand::thread_rng();
 
-        let test_buf = (0..2).map(|_| rng.gen()).collect::<Vec<_>>();
+        let test_buf = Arc::new((0..2).map(|_| rng.gen()).collect::<Vec<_>>());
         let custom = Custom::new(test_buf.clone(), 4 * kHz)?;
 
         assert_eq!(4. * kHz, custom.sampling_config().freq());
@@ -67,7 +67,7 @@ mod tests {
     fn new_nearest() -> anyhow::Result<()> {
         let mut rng = rand::thread_rng();
 
-        let test_buf = (0..2).map(|_| rng.gen()).collect::<Vec<_>>();
+        let test_buf = Arc::new((0..2).map(|_| rng.gen()).collect::<Vec<_>>());
         let custom = Custom::new_nearest(test_buf.clone(), 4 * kHz);
 
         assert_eq!(4. * kHz, custom.sampling_config().freq());

--- a/autd3/src/datagram/modulation/fourier.rs
+++ b/autd3/src/datagram/modulation/fourier.rs
@@ -17,13 +17,17 @@ pub struct Fourier<S: SamplingMode> {
 impl<S: SamplingMode> Fourier<S> {
     pub fn new(componens: impl IntoIterator<Item = Sine<S>>) -> Result<Self, AUTDInternalError> {
         let components = componens.into_iter().collect::<Vec<_>>();
-        if components.is_empty() {
-            return Err(AUTDInternalError::ModulationError(
+        let config = components
+            .get(0)
+            .ok_or(AUTDInternalError::ModulationError(
                 "Components must not be empty".to_string(),
-            ));
-        }
-        let config = components[0].sampling_config();
-        if !components.iter().all(|c| c.sampling_config() == config) {
+            ))?
+            .sampling_config();
+        if !components
+            .iter()
+            .skip(1)
+            .all(|c| c.sampling_config() == config)
+        {
             return Err(AUTDInternalError::ModulationError(
                 "All components must have the same sampling configuration".to_string(),
             ));

--- a/autd3/src/datagram/modulation/fourier.rs
+++ b/autd3/src/datagram/modulation/fourier.rs
@@ -18,7 +18,7 @@ impl<S: SamplingMode> Fourier<S> {
     pub fn new(componens: impl IntoIterator<Item = Sine<S>>) -> Result<Self, AUTDInternalError> {
         let components = componens.into_iter().collect::<Vec<_>>();
         let config = components
-            .get(0)
+            .first()
             .ok_or(AUTDInternalError::ModulationError(
                 "Components must not be empty".to_string(),
             ))?

--- a/autd3/src/datagram/modulation/fourier.rs
+++ b/autd3/src/datagram/modulation/fourier.rs
@@ -47,20 +47,22 @@ impl<S: SamplingMode> Modulation for Fourier<S> {
             .iter()
             .map(|c| c.calc())
             .collect::<Result<Vec<_>, _>>()?;
-        Ok(buffers
-            .iter()
-            .fold(
-                vec![0usize; buffers.iter().fold(1, |acc, x| lcm(acc, x.len()))],
-                |acc, x| {
-                    acc.iter()
-                        .zip(x.iter().cycle())
-                        .map(|(a, &b)| a + b as usize)
-                        .collect::<Vec<_>>()
-                },
-            )
-            .iter()
-            .map(|x| (x / buffers.len()) as u8)
-            .collect::<Vec<_>>())
+        Ok(Arc::new(
+            buffers
+                .iter()
+                .fold(
+                    vec![0usize; buffers.iter().fold(1, |acc, x| lcm(acc, x.len()))],
+                    |acc, x| {
+                        acc.iter()
+                            .zip(x.iter().cycle())
+                            .map(|(a, &b)| a + b as usize)
+                            .collect::<Vec<_>>()
+                    },
+                )
+                .iter()
+                .map(|x| (x / buffers.len()) as u8)
+                .collect::<Vec<_>>(),
+        ))
     }
 
     #[tracing::instrument(level = "debug", skip(self, _geometry), fields(%self.config, %self.loop_behavior))]

--- a/autd3/src/datagram/modulation/mixer.rs
+++ b/autd3/src/datagram/modulation/mixer.rs
@@ -18,7 +18,7 @@ impl<S: SamplingMode> Mixer<S> {
     pub fn new(componens: impl IntoIterator<Item = Sine<S>>) -> Result<Self, AUTDInternalError> {
         let components = componens.into_iter().collect::<Vec<_>>();
         let config = components
-            .get(0)
+            .first()
             .ok_or(AUTDInternalError::ModulationError(
                 "Components must not be empty".to_string(),
             ))?

--- a/autd3/src/datagram/modulation/mixer.rs
+++ b/autd3/src/datagram/modulation/mixer.rs
@@ -17,13 +17,17 @@ pub struct Mixer<S: SamplingMode> {
 impl<S: SamplingMode> Mixer<S> {
     pub fn new(componens: impl IntoIterator<Item = Sine<S>>) -> Result<Self, AUTDInternalError> {
         let components = componens.into_iter().collect::<Vec<_>>();
-        if components.is_empty() {
-            return Err(AUTDInternalError::ModulationError(
+        let config = components
+            .get(0)
+            .ok_or(AUTDInternalError::ModulationError(
                 "Components must not be empty".to_string(),
-            ));
-        }
-        let config = components[0].sampling_config();
-        if !components.iter().all(|c| c.sampling_config() == config) {
+            ))?
+            .sampling_config();
+        if !components
+            .iter()
+            .skip(1)
+            .all(|c| c.sampling_config() == config)
+        {
             return Err(AUTDInternalError::ModulationError(
                 "All components must have the same sampling configuration".to_string(),
             ));

--- a/autd3/src/datagram/modulation/mixer.rs
+++ b/autd3/src/datagram/modulation/mixer.rs
@@ -48,26 +48,28 @@ impl<S: SamplingMode> Modulation for Mixer<S> {
             .map(|c| c.calc())
             .map(|v| {
                 v.map(|v| {
-                    v.into_iter()
-                        .map(|x| x as f32 / u8::MAX as f32)
+                    v.iter()
+                        .map(|x| *x as f32 / u8::MAX as f32)
                         .collect::<Vec<_>>()
                 })
             })
             .collect::<Result<Vec<_>, _>>()?;
-        Ok(buffers
-            .iter()
-            .fold(
-                vec![1.0; buffers.iter().fold(1, |acc, x| lcm(acc, x.len()))],
-                |acc, x| {
-                    acc.iter()
-                        .zip(x.iter().cycle())
-                        .map(|(&a, &b)| a * b)
-                        .collect::<Vec<_>>()
-                },
-            )
-            .iter()
-            .map(|x| (x * u8::MAX as f32) as u8)
-            .collect::<Vec<_>>())
+        Ok(Arc::new(
+            buffers
+                .iter()
+                .fold(
+                    vec![1.0; buffers.iter().fold(1, |acc, x| lcm(acc, x.len()))],
+                    |acc, x| {
+                        acc.iter()
+                            .zip(x.iter().cycle())
+                            .map(|(&a, &b)| a * b)
+                            .collect::<Vec<_>>()
+                    },
+                )
+                .iter()
+                .map(|x| (x * u8::MAX as f32) as u8)
+                .collect::<Vec<_>>(),
+        ))
     }
 
     #[tracing::instrument(level = "debug", skip(self, _geometry), fields(%self.config, %self.loop_behavior))]

--- a/autd3/src/datagram/modulation/sine.rs
+++ b/autd3/src/datagram/modulation/sine.rs
@@ -52,7 +52,7 @@ impl Sine<ExactFreq> {
         }
     }
 
-    pub const fn from_freq_nearest(freq: Freq<f32>) -> Sine<NearestFreq> {
+    pub const fn new_nearest(freq: Freq<f32>) -> Sine<NearestFreq> {
         Sine {
             freq,
             intensity: u8::MAX,
@@ -211,11 +211,8 @@ mod tests {
         Err(AUTDInternalError::ModulationError("Frequency must not be zero. If intentional, Use `Static` instead.".to_owned())),
         0.*Hz
     )]
-    fn from_freq_nearest(
-        #[case] expect: Result<Vec<u8>, AUTDInternalError>,
-        #[case] freq: Freq<f32>,
-    ) {
-        let m = Sine::from_freq_nearest(freq);
+    fn new_nearest(#[case] expect: Result<Vec<u8>, AUTDInternalError>, #[case] freq: Freq<f32>) {
+        let m = Sine::new_nearest(freq);
         assert_eq!(freq, m.freq());
         assert_eq!(u8::MAX, m.intensity());
         assert_eq!(u8::MAX / 2, m.offset());

--- a/autd3/src/datagram/modulation/sine.rs
+++ b/autd3/src/datagram/modulation/sine.rs
@@ -40,7 +40,7 @@ pub struct Sine<S: SamplingMode> {
 }
 
 impl Sine<ExactFreq> {
-    pub fn new<S: SamplingModeInference>(freq: S) -> Sine<S::T> {
+    pub const fn new<S: SamplingModeInference>(freq: S) -> Sine<S::T> {
         Sine {
             freq,
             intensity: u8::MAX,

--- a/autd3/src/datagram/modulation/square.rs
+++ b/autd3/src/datagram/modulation/square.rs
@@ -19,7 +19,6 @@ use derive_more::Display;
     loop_behavior
 )]
 pub struct Square<S: SamplingMode> {
-    #[get]
     freq: S::T,
     #[get]
     #[set]
@@ -59,6 +58,12 @@ impl Square<ExactFreq> {
             loop_behavior: LoopBehavior::infinite(),
             __phantom: std::marker::PhantomData,
         }
+    }
+}
+
+impl<S: SamplingMode> Square<S> {
+    pub fn freq(&self) -> S::T {
+        S::freq(self.freq, self.config)
     }
 }
 
@@ -191,22 +196,6 @@ mod tests {
     #[case(
         Ok(vec![255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
         200.*Hz
-    )]
-    #[case(
-        Err(AUTDInternalError::ModulationError("Frequency (2000 Hz) is equal to or greater than the Nyquist frequency (2000 Hz)".to_owned())),
-        2000.*Hz
-    )]
-    #[case(
-        Err(AUTDInternalError::ModulationError("Frequency (4000 Hz) is equal to or greater than the Nyquist frequency (2000 Hz)".to_owned())),
-        4000.*Hz
-    )]
-    #[case(
-        Err(AUTDInternalError::ModulationError("Frequency (-0.1 Hz) must be positive".to_owned())),
-        -0.1*Hz
-    )]
-    #[case(
-        Err(AUTDInternalError::ModulationError("Frequency must not be zero. If intentional, Use `Static` instead.".to_owned())),
-        0.*Hz
     )]
     fn new_nearest(#[case] expect: Result<Vec<u8>, AUTDInternalError>, #[case] freq: Freq<f32>) {
         let m = Square::new_nearest(freq);

--- a/autd3/src/datagram/modulation/square.rs
+++ b/autd3/src/datagram/modulation/square.rs
@@ -49,7 +49,7 @@ impl Square<ExactFreq> {
         }
     }
 
-    pub const fn from_freq_nearest(freq: Freq<f32>) -> Square<NearestFreq> {
+    pub const fn new_nearest(freq: Freq<f32>) -> Square<NearestFreq> {
         Square {
             freq,
             low: u8::MIN,
@@ -208,11 +208,8 @@ mod tests {
         Err(AUTDInternalError::ModulationError("Frequency must not be zero. If intentional, Use `Static` instead.".to_owned())),
         0.*Hz
     )]
-    fn from_freq_nearest(
-        #[case] expect: Result<Vec<u8>, AUTDInternalError>,
-        #[case] freq: Freq<f32>,
-    ) {
-        let m = Square::from_freq_nearest(freq);
+    fn new_nearest(#[case] expect: Result<Vec<u8>, AUTDInternalError>, #[case] freq: Freq<f32>) {
+        let m = Square::new_nearest(freq);
         assert_eq!(freq, m.freq());
         assert_eq!(u8::MIN, m.low());
         assert_eq!(u8::MAX, m.high());

--- a/autd3/src/datagram/modulation/static.rs
+++ b/autd3/src/datagram/modulation/static.rs
@@ -32,7 +32,7 @@ impl Static {
 impl Modulation for Static {
     fn calc(&self) -> ModulationCalcResult {
         let intensity = self.intensity;
-        Ok(vec![intensity; 2])
+        Ok(Arc::new(vec![intensity; 2]))
     }
 
     #[tracing::instrument(level = "debug", skip(_geometry))]
@@ -58,7 +58,7 @@ mod tests {
         let m = Static::default();
         assert_eq!(u8::MAX, m.intensity());
         assert_eq!(SamplingConfig::new(NonZeroU16::MAX), m.sampling_config());
-        assert_eq!(Ok(vec![u8::MAX, u8::MAX]), m.calc());
+        assert_eq!(Ok(Arc::new(vec![u8::MAX, u8::MAX])), m.calc());
     }
 
     #[test]
@@ -66,6 +66,6 @@ mod tests {
         let m = Static::with_intensity(0x1F);
         assert_eq!(0x1F, m.intensity());
         assert_eq!(SamplingConfig::new(NonZeroU16::MAX), m.sampling_config());
-        assert_eq!(Ok(vec![0x1F, 0x1F]), m.calc());
+        assert_eq!(Ok(Arc::new(vec![0x1F, 0x1F])), m.calc());
     }
 }

--- a/examples/src/tests/user_defined_gain_modulation.rs
+++ b/examples/src/tests/user_defined_gain_modulation.rs
@@ -33,9 +33,11 @@ impl Burst {
 
 impl Modulation for Burst {
     fn calc(&self) -> ModulationCalcResult {
-        Ok((0..4000)
-            .map(|i| if i == 3999 { u8::MAX } else { u8::MIN })
-            .collect())
+        Ok(Arc::new(
+            (0..4000)
+                .map(|i| if i == 3999 { u8::MAX } else { u8::MIN })
+                .collect(),
+        ))
     }
 }
 


### PR DESCRIPTION
- **refactor `autd3`**
- **rename from `from_freq_nearest` to `new_nearest`**
- **return actual frequency by `Sine,Square::freq`**
- **use `Arc<Vec<u8>>` instead of `Vec<u8>` as `ModulationCalcResult`**
- **bump to v27.0.0-rc.1**
