### PR TITLE
bump to v28.0.0-alpha.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "28.0.0-alpha.0"
+version = "28.0.0-alpha.1"
 authors = ["shun suzuki <suzuki@hapis.k.u-tokyo.ac.jp>"]
 edition = "2021"
 license = "MIT"
@@ -62,13 +62,13 @@ approx = "0.5.1"
 ta = "0.5.0"
 csv = "1.3.0"
 seq-macro = "0.3.5"
-autd3 = { path = "./autd3", version = "28.0.0-alpha.0" }
-autd3-driver = { path = "./autd3-driver", version = "28.0.0-alpha.0" }
-autd3-derive = { path = "./autd3-derive", version = "28.0.0-alpha.0" }
-autd3-gain-holo = { path = "./autd3-gain-holo", version = "28.0.0-alpha.0" }
-autd3-link-simulator = { path = "./autd3-link-simulator", version = "28.0.0-alpha.0" }
-autd3-link-soem = { path = "./autd3-link-soem", version = "28.0.0-alpha.0" }
-autd3-link-twincat = { path = "./autd3-link-twincat", version = "28.0.0-alpha.0" }
-autd3-modulation-audio-file = { path = "./autd3-modulation-audio-file", version = "28.0.0-alpha.0" }
-autd3-firmware-emulator = { path = "./autd3-firmware-emulator", version = "28.0.0-alpha.0" }
-autd3-protobuf = { path = "./autd3-protobuf", version = "28.0.0-alpha.0" }
+autd3 = { path = "./autd3", version = "28.0.0-alpha.1" }
+autd3-driver = { path = "./autd3-driver", version = "28.0.0-alpha.1" }
+autd3-derive = { path = "./autd3-derive", version = "28.0.0-alpha.1" }
+autd3-gain-holo = { path = "./autd3-gain-holo", version = "28.0.0-alpha.1" }
+autd3-link-simulator = { path = "./autd3-link-simulator", version = "28.0.0-alpha.1" }
+autd3-link-soem = { path = "./autd3-link-soem", version = "28.0.0-alpha.1" }
+autd3-link-twincat = { path = "./autd3-link-twincat", version = "28.0.0-alpha.1" }
+autd3-modulation-audio-file = { path = "./autd3-modulation-audio-file", version = "28.0.0-alpha.1" }
+autd3-firmware-emulator = { path = "./autd3-firmware-emulator", version = "28.0.0-alpha.1" }
+autd3-protobuf = { path = "./autd3-protobuf", version = "28.0.0-alpha.1" }

--- a/autd3-driver/src/datagram/mod.rs
+++ b/autd3-driver/src/datagram/mod.rs
@@ -30,7 +30,7 @@ pub use modulation::{
 pub use pulse_width_encoder::PulseWidthEncoder;
 pub use reads_fpga_state::ReadsFPGAState;
 pub use segment::SwapSegment;
-pub use silencer::{FixedCompletionTime, FixedUpdateRate, Silencer};
+pub use silencer::{FixedCompletionTime, FixedUpdateRate, Silencer, WithSampling};
 pub use stm::{FociSTM, GainSTM, STMConfig, STMConfigNearest};
 pub use synchronize::Synchronize;
 pub use with_parallel_threshold::{

--- a/autd3-driver/src/datagram/silencer.rs
+++ b/autd3-driver/src/datagram/silencer.rs
@@ -25,7 +25,7 @@ pub trait WithSampling {
 pub trait SilencerConfig: std::fmt::Debug + Clone + Copy {}
 impl SilencerConfig for () {}
 
-#[derive(Debug, Clone, Copy, Builder)]
+#[derive(Debug, Clone, Copy, Builder, PartialEq, Eq)]
 pub struct FixedCompletionTime {
     #[get]
     pub intensity: Duration,
@@ -34,7 +34,7 @@ pub struct FixedCompletionTime {
 }
 impl SilencerConfig for FixedCompletionTime {}
 
-#[derive(Debug, Clone, Copy, Builder)]
+#[derive(Debug, Clone, Copy, Builder, PartialEq, Eq)]
 pub struct FixedUpdateRate {
     #[get]
     pub intensity: NonZeroU16,

--- a/autd3-driver/src/datagram/stm/foci.rs
+++ b/autd3-driver/src/datagram/stm/foci.rs
@@ -144,6 +144,18 @@ impl<const N: usize> DatagramST for FociSTM<N> {
     }
 }
 
+// GRCOV_EXCL_START
+impl<const N: usize> FociSTM<N> {
+    pub unsafe fn uninit() -> Self /* ignore miri */ {
+        Self {
+            control_points: vec![],
+            loop_behavior: LoopBehavior::infinite(),
+            sampling_config: SamplingConfig::FREQ_40K,
+        }
+    }
+}
+// GRCOV_EXCL_STOP
+
 #[cfg(test)]
 mod tests {
     use crate::{

--- a/autd3-driver/src/datagram/stm/foci.rs
+++ b/autd3-driver/src/datagram/stm/foci.rs
@@ -146,6 +146,7 @@ impl<const N: usize> DatagramST for FociSTM<N> {
 
 // GRCOV_EXCL_START
 impl<const N: usize> FociSTM<N> {
+    #[allow(clippy::missing_safety_doc)]
     pub unsafe fn uninit() -> Self /* ignore miri */ {
         Self {
             control_points: vec![],

--- a/autd3-driver/src/datagram/stm/gain.rs
+++ b/autd3-driver/src/datagram/stm/gain.rs
@@ -175,6 +175,7 @@ impl<G: Gain> DatagramST for GainSTM<G> {
 
 // GRCOV_EXCL_START
 impl GainSTM<BoxedGain<'static>> {
+    #[allow(clippy::missing_safety_doc)]
     pub unsafe fn uninit() -> Self /* ignore miri */ {
         Self {
             gains: vec![],

--- a/autd3-driver/src/datagram/stm/gain.rs
+++ b/autd3-driver/src/datagram/stm/gain.rs
@@ -173,6 +173,19 @@ impl<G: Gain> DatagramST for GainSTM<G> {
     }
 }
 
+// GRCOV_EXCL_START
+impl GainSTM<BoxedGain<'static>> {
+    pub unsafe fn uninit() -> Self /* ignore miri */ {
+        Self {
+            gains: vec![],
+            loop_behavior: LoopBehavior::infinite(),
+            sampling_config: SamplingConfig::FREQ_40K,
+            mode: GainSTMMode::PhaseIntensityFull,
+        }
+    }
+}
+// GRCOV_EXCL_STOP
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/autd3-firmware-emulator/src/fpga/emulator/modulation.rs
+++ b/autd3-firmware-emulator/src/fpga/emulator/modulation.rs
@@ -56,9 +56,13 @@ impl FPGAEmulator {
     }
 
     pub fn modulation_buffer(&self, segment: Segment) -> Vec<u8> {
-        (0..self.modulation_cycle(segment))
-            .map(|i| self.modulation_at(segment, i))
-            .collect()
+        let mut dst = vec![0; self.modulation_cycle(segment)];
+        self.modulation_buffer_inplace(segment, &mut dst);
+        dst
+    }
+
+    pub fn modulation_buffer_inplace(&self, segment: Segment, dst: &mut [u8]) {
+        (0..self.modulation_cycle(segment)).for_each(|i| dst[i] = self.modulation_at(segment, i));
     }
 
     pub fn modulation_transition_mode(&self) -> TransitionMode {

--- a/autd3-firmware-emulator/src/fpga/emulator/pwe.rs
+++ b/autd3-firmware-emulator/src/fpga/emulator/pwe.rs
@@ -10,11 +10,18 @@ impl FPGAEmulator {
     }
 
     pub fn pulse_width_encoder_table(&self) -> Vec<u8> {
+        let mut dst = vec![0; 256];
+        self.pulse_width_encoder_table_inplace(&mut dst);
+        dst
+    }
+
+    pub fn pulse_width_encoder_table_inplace(&self, dst: &mut [u8]) {
         self.mem
             .duty_table_bram()
             .iter()
             .flat_map(|&d| vec![(d & 0xFF) as u8, (d >> 8) as u8])
-            .collect()
+            .enumerate()
+            .for_each(|(i, v)| dst[i] = v);
     }
 
     pub fn to_pulse_width(&self, a: EmitIntensity, b: u8) -> u8 {

--- a/autd3-firmware-emulator/src/fpga/emulator/stm/gain.rs
+++ b/autd3-firmware-emulator/src/fpga/emulator/stm/gain.rs
@@ -6,7 +6,7 @@ use autd3_driver::{
 use crate::FPGAEmulator;
 
 impl FPGAEmulator {
-    pub(crate) fn gain_stm_drives(&self, segment: Segment, idx: usize) -> Vec<Drive> {
+    pub(crate) fn gain_stm_drives_inplace(&self, segment: Segment, idx: usize, dst: &mut [Drive]) {
         match segment {
             Segment::S0 => self.mem.stm_bram_0(),
             Segment::S1 => self.mem.stm_bram_1(),
@@ -15,12 +15,12 @@ impl FPGAEmulator {
         .iter()
         .skip(256 * idx)
         .take(self.mem.num_transducers)
-        .map(|&d| {
-            Drive::new(
+        .enumerate()
+        .for_each(|(i, &d)| {
+            dst[i] = Drive::new(
                 Phase::new((d & 0xFF) as u8),
                 EmitIntensity::new(((d >> 8) & 0xFF) as u8),
             )
         })
-        .collect()
     }
 }

--- a/autd3-firmware-emulator/src/fpga/emulator/stm/mod.rs
+++ b/autd3-firmware-emulator/src/fpga/emulator/stm/mod.rs
@@ -93,10 +93,16 @@ impl FPGAEmulator {
     }
 
     pub fn drives_at(&self, segment: Segment, idx: usize) -> Vec<Drive> {
+        let mut dst = vec![Drive::null(); self.mem.num_transducers];
+        self.drives_at_inplace(segment, idx, &mut dst);
+        dst
+    }
+
+    pub fn drives_at_inplace(&self, segment: Segment, idx: usize, dst: &mut [Drive]) {
         if self.is_stm_gain_mode(segment) {
-            self.gain_stm_drives(segment, idx)
+            self.gain_stm_drives_inplace(segment, idx, dst)
         } else {
-            self.foci_stm_drives(segment, idx)
+            self.foci_stm_drives_inplace(segment, idx, dst)
         }
     }
 }

--- a/autd3-firmware-emulator/tests/op/clear.rs
+++ b/autd3-firmware-emulator/tests/op/clear.rs
@@ -85,12 +85,18 @@ fn send_clear() -> anyhow::Result<()> {
     assert_eq!(Ok(()), send(&mut cpu, d, &geometry, &mut tx));
 
     assert!(!cpu.reads_fpga_state());
-    assert_eq!((256, 256), cpu.fpga().silencer_update_rate());
     assert_eq!(
-        (
-            SILENCER_STEPS_INTENSITY_DEFAULT as _,
-            SILENCER_STEPS_PHASE_DEFAULT as _
-        ),
+        FixedUpdateRate {
+            intensity: NonZeroU16::new(256).unwrap(),
+            phase: NonZeroU16::new(256).unwrap(),
+        },
+        cpu.fpga().silencer_update_rate()
+    );
+    assert_eq!(
+        FixedCompletionTime {
+            intensity: SILENCER_STEPS_INTENSITY_DEFAULT * ULTRASOUND_PERIOD,
+            phase: SILENCER_STEPS_PHASE_DEFAULT * ULTRASOUND_PERIOD,
+        },
         cpu.fpga().silencer_completion_steps()
     );
     assert!(cpu.fpga().silencer_fixed_completion_steps_mode());

--- a/autd3/src/datagram/modulation/resample/resampler/mod.rs
+++ b/autd3/src/datagram/modulation/resample/resampler/mod.rs
@@ -5,7 +5,7 @@ use autd3_driver::{defined::Freq, derive::SamplingConfig};
 pub use sinc::SincInterpolation;
 pub use window::*;
 
-pub trait Resampler: std::fmt::Debug {
+pub trait Resampler: std::fmt::Debug + Send + Sync {
     fn upsample(&self, buffer: &[u8], ratio: f64) -> Vec<u8>;
     fn downsample(&self, buffer: &[u8], ratio: f64) -> Vec<u8>;
     fn resample(&self, buffer: &[u8], source: Freq<f32>, target: SamplingConfig) -> Vec<u8> {

--- a/autd3/src/datagram/modulation/resample/resampler/window/mod.rs
+++ b/autd3/src/datagram/modulation/resample/resampler/window/mod.rs
@@ -4,7 +4,7 @@ mod rectangular;
 pub use blackman::Blackman;
 pub use rectangular::Rectangular;
 
-pub trait InterpolationWindow: std::fmt::Debug + Clone + Copy + PartialEq {
+pub trait InterpolationWindow: std::fmt::Debug + Clone + Copy + PartialEq + Send + Sync {
     fn window_size(&self) -> usize;
     fn value(&self, k: usize) -> f64;
 }


### PR DESCRIPTION
- **make `WithSampling` pub**
- **make `Resampler` implement `Send` and `Sync`**
- **update `FPGAEmulator`**
- **add `uninit` fn for `FociSTM` and `GainSTM`**
- **add inplace fn to avoid allocation**
- **add `#[allow(clippy::missing_safety_doc)]`**
- **bump to v28.0.0-alpha.1**
