### PR TITLE
bump to v29.0.3-alpha.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "29.0.0-alpha.2"
+version = "29.0.0-alpha.3"
 authors = ["shun suzuki <suzuki@hapis.k.u-tokyo.ac.jp>"]
 edition = "2021"
 license = "MIT"
@@ -66,13 +66,13 @@ csv = "1.3.0"
 seq-macro = "0.3.5"
 spin_sleep = "1.2.1"
 zerocopy = { version = "0.8.6", features = ["derive"] }
-autd3 = { path = "./autd3", version = "29.0.0-alpha.2" }
-autd3-driver = { path = "./autd3-driver", version = "29.0.0-alpha.2" }
-autd3-derive = { path = "./autd3-derive", version = "29.0.0-alpha.2" }
-autd3-gain-holo = { path = "./autd3-gain-holo", version = "29.0.0-alpha.2" }
-autd3-link-simulator = { path = "./autd3-link-simulator", version = "29.0.0-alpha.2" }
-autd3-link-soem = { path = "./autd3-link-soem", version = "29.0.0-alpha.2" }
-autd3-link-twincat = { path = "./autd3-link-twincat", version = "29.0.0-alpha.2" }
-autd3-modulation-audio-file = { path = "./autd3-modulation-audio-file", version = "29.0.0-alpha.2" }
-autd3-firmware-emulator = { path = "./autd3-firmware-emulator", version = "29.0.0-alpha.2" }
-autd3-protobuf = { path = "./autd3-protobuf", version = "29.0.0-alpha.2" }
+autd3 = { path = "./autd3", version = "29.0.0-alpha.3" }
+autd3-driver = { path = "./autd3-driver", version = "29.0.0-alpha.3" }
+autd3-derive = { path = "./autd3-derive", version = "29.0.0-alpha.3" }
+autd3-gain-holo = { path = "./autd3-gain-holo", version = "29.0.0-alpha.3" }
+autd3-link-simulator = { path = "./autd3-link-simulator", version = "29.0.0-alpha.3" }
+autd3-link-soem = { path = "./autd3-link-soem", version = "29.0.0-alpha.3" }
+autd3-link-twincat = { path = "./autd3-link-twincat", version = "29.0.0-alpha.3" }
+autd3-modulation-audio-file = { path = "./autd3-modulation-audio-file", version = "29.0.0-alpha.3" }
+autd3-firmware-emulator = { path = "./autd3-firmware-emulator", version = "29.0.0-alpha.3" }
+autd3-protobuf = { path = "./autd3-protobuf", version = "29.0.0-alpha.3" }

--- a/autd3-driver/src/datagram/tuple.rs
+++ b/autd3-driver/src/datagram/tuple.rs
@@ -54,7 +54,11 @@ where
     }
 
     fn parallel_threshold(&self) -> Option<usize> {
-        self.0.parallel_threshold().into_iter().chain(self.1.parallel_threshold()).min()
+        self.0
+            .parallel_threshold()
+            .into_iter()
+            .chain(self.1.parallel_threshold())
+            .min()
     }
 }
 

--- a/autd3-driver/src/ethercat/consts.rs
+++ b/autd3-driver/src/ethercat/consts.rs
@@ -1,8 +1,9 @@
+use std::time::Duration;
+
 pub const EC_OUTPUT_FRAME_SIZE: usize = 626;
 pub const EC_INPUT_FRAME_SIZE: usize = 2;
 
-pub const EC_CYCLE_TIME_BASE_MICRO_SEC: u64 = 500;
-pub const EC_CYCLE_TIME_BASE_NANO_SEC: u64 = EC_CYCLE_TIME_BASE_MICRO_SEC * 1000;
+pub const EC_CYCLE_TIME_BASE: Duration = Duration::from_micros(500);
 
 pub const ECAT_DC_SYS_TIME_BASE: time::OffsetDateTime =
     time::macros::datetime!(2000-01-01 0:00 UTC);

--- a/autd3-firmware-emulator/tests/op/modulation.rs
+++ b/autd3-firmware-emulator/tests/op/modulation.rs
@@ -260,7 +260,7 @@ fn send_mod_invalid_transition_mode() -> anyhow::Result<()> {
 #[rstest::rstest]
 #[test]
 #[case(Ok(()), ECAT_DC_SYS_TIME_BASE, ECAT_DC_SYS_TIME_BASE + Duration::from_nanos(SYS_TIME_TRANSITION_MARGIN))]
-#[case(Err(AUTDInternalError::MissTransitionTime), ECAT_DC_SYS_TIME_BASE, ECAT_DC_SYS_TIME_BASE + Duration::from_nanos(SYS_TIME_TRANSITION_MARGIN-autd3_driver::ethercat::EC_CYCLE_TIME_BASE_NANO_SEC))]
+#[case(Err(AUTDInternalError::MissTransitionTime), ECAT_DC_SYS_TIME_BASE, ECAT_DC_SYS_TIME_BASE + Duration::from_nanos(SYS_TIME_TRANSITION_MARGIN)-autd3_driver::ethercat::EC_CYCLE_TIME_BASE)]
 #[case(Err(AUTDInternalError::MissTransitionTime), ECAT_DC_SYS_TIME_BASE + Duration::from_nanos(1), ECAT_DC_SYS_TIME_BASE + Duration::from_nanos(SYS_TIME_TRANSITION_MARGIN))]
 #[cfg_attr(miri, ignore)]
 fn test_miss_transition_time(

--- a/autd3-firmware-emulator/tests/op/stm/foci.rs
+++ b/autd3-firmware-emulator/tests/op/stm/foci.rs
@@ -313,7 +313,7 @@ fn send_foci_stm_invalid_transition_mode() -> anyhow::Result<()> {
 #[rstest::rstest]
 #[test]
 #[case(Ok(()), ECAT_DC_SYS_TIME_BASE, ECAT_DC_SYS_TIME_BASE + Duration::from_nanos(SYS_TIME_TRANSITION_MARGIN))]
-#[case(Err(AUTDInternalError::MissTransitionTime), ECAT_DC_SYS_TIME_BASE, ECAT_DC_SYS_TIME_BASE + Duration::from_nanos(SYS_TIME_TRANSITION_MARGIN-autd3_driver::ethercat::EC_CYCLE_TIME_BASE_NANO_SEC))]
+#[case(Err(AUTDInternalError::MissTransitionTime), ECAT_DC_SYS_TIME_BASE, ECAT_DC_SYS_TIME_BASE + Duration::from_nanos(SYS_TIME_TRANSITION_MARGIN)-autd3_driver::ethercat::EC_CYCLE_TIME_BASE)]
 #[case(Err(AUTDInternalError::MissTransitionTime), ECAT_DC_SYS_TIME_BASE + Duration::from_nanos(1), ECAT_DC_SYS_TIME_BASE + Duration::from_nanos(SYS_TIME_TRANSITION_MARGIN))]
 #[cfg_attr(miri, ignore)]
 fn test_miss_transition_time(

--- a/autd3-link-soem/src/local/builder.rs
+++ b/autd3-link-soem/src/local/builder.rs
@@ -1,7 +1,4 @@
-use std::{
-    num::{NonZeroU64, NonZeroUsize},
-    time::Duration,
-};
+use std::{num::NonZeroUsize, time::Duration};
 
 use super::{
     error_handler::{ErrHandler, Status},
@@ -9,7 +6,7 @@ use super::{
     SyncMode, SOEM,
 };
 
-use autd3_driver::{derive::*, link::LinkBuilder};
+use autd3_driver::{derive::*, ethercat::EC_CYCLE_TIME_BASE, link::LinkBuilder};
 
 use thread_priority::ThreadPriority;
 
@@ -29,13 +26,13 @@ pub struct SOEMBuilder {
     pub(crate) ifname: String,
     #[get]
     #[set]
-    pub(crate) state_check_interval: std::time::Duration,
+    pub(crate) state_check_interval: Duration,
     #[get]
     #[set]
-    pub(crate) sync0_cycle: NonZeroU64,
+    pub(crate) sync0_cycle: Duration,
     #[get]
     #[set]
-    pub(crate) send_cycle: NonZeroU64,
+    pub(crate) send_cycle: Duration,
     #[get]
     #[set]
     pub(crate) thread_priority: ThreadPriority,
@@ -46,10 +43,10 @@ pub struct SOEMBuilder {
     pub(crate) err_handler: Option<ErrHandler>,
     #[get]
     #[set]
-    pub(crate) sync_tolerance: std::time::Duration,
+    pub(crate) sync_tolerance: Duration,
     #[get]
     #[set]
-    pub(crate) sync_timeout: std::time::Duration,
+    pub(crate) sync_timeout: Duration,
 }
 
 impl Default for SOEMBuilder {
@@ -66,8 +63,8 @@ impl SOEMBuilder {
             sync_mode: SyncMode::DC,
             ifname: String::new(),
             state_check_interval: Duration::from_millis(100),
-            sync0_cycle: NonZeroU64::new(2).unwrap(),
-            send_cycle: NonZeroU64::new(2).unwrap(),
+            sync0_cycle: EC_CYCLE_TIME_BASE * 2,
+            send_cycle: EC_CYCLE_TIME_BASE * 2,
             thread_priority: ThreadPriority::Max,
             #[cfg(target_os = "windows")]
             process_priority: super::ProcessPriority::High,

--- a/autd3-link-soem/src/local/link_soem.rs
+++ b/autd3-link-soem/src/local/link_soem.rs
@@ -18,7 +18,7 @@ pub use crate::local::builder::SOEMBuilder;
 
 use autd3_driver::{
     error::AUTDInternalError,
-    ethercat::{SyncMode, EC_CYCLE_TIME_BASE_NANO_SEC},
+    ethercat::{SyncMode, EC_CYCLE_TIME_BASE},
     firmware::cpu::{RxMessage, TxMessage},
     link::Link,
 };
@@ -89,10 +89,17 @@ impl SOEM {
                 sync_timeout,
             } = builder;
 
+            // ceilling to multiple of EC_CYCLE_TIME_BASE
             let ec_sync0_cycle =
-                Duration::from_nanos(sync0_cycle.get() * EC_CYCLE_TIME_BASE_NANO_SEC);
+                ((sync0_cycle.max(Duration::from_nanos(1)) - Duration::from_nanos(1)).as_nanos()
+                    / EC_CYCLE_TIME_BASE.as_nanos()
+                    + 1) as u32
+                    * EC_CYCLE_TIME_BASE;
             let ec_send_cycle =
-                Duration::from_nanos(send_cycle.get() * EC_CYCLE_TIME_BASE_NANO_SEC);
+                ((send_cycle.max(Duration::from_nanos(1)) - Duration::from_nanos(1)).as_nanos()
+                    / EC_CYCLE_TIME_BASE.as_nanos()
+                    + 1) as u32
+                    * EC_CYCLE_TIME_BASE;
 
             let ifname = if ifname.is_empty() {
                 tracing::info!("No interface name is specified. Looking up AUTD device.");

--- a/autd3-link-soem/src/local/mod.rs
+++ b/autd3-link-soem/src/local/mod.rs
@@ -4,7 +4,6 @@ mod error_handler;
 mod ethernet_adapters;
 mod iomap;
 pub mod link_soem;
-#[cfg(target_os = "windows")]
 mod process_priority;
 mod sleep;
 mod soem_bindings;
@@ -15,7 +14,6 @@ pub use autd3_driver::ethercat::SyncMode;
 pub use error_handler::Status;
 pub use ethernet_adapters::EthernetAdapters;
 pub use link_soem::SOEM;
-#[cfg(target_os = "windows")]
 pub use process_priority::ProcessPriority;
 pub use thread_priority::{ThreadPriority, ThreadPriorityValue};
 pub use timer_strategy::TimerStrategy;

--- a/autd3-link-soem/src/local/process_priority.rs
+++ b/autd3-link-soem/src/local/process_priority.rs
@@ -9,6 +9,7 @@ pub enum ProcessPriority {
     Realtime = 5,
 }
 
+#[cfg(target_os = "windows")]
 impl From<ProcessPriority> for windows::Win32::System::Threading::PROCESS_CREATION_FLAGS {
     fn from(val: ProcessPriority) -> windows::Win32::System::Threading::PROCESS_CREATION_FLAGS {
         match val {

--- a/autd3-link-soem/src/local/sleep.rs
+++ b/autd3-link-soem/src/local/sleep.rs
@@ -8,7 +8,15 @@ pub(crate) struct StdSleep {}
 
 impl Sleep for StdSleep {
     fn sleep(duration: Duration) {
-        std::thread::sleep(duration)
+        #[cfg(target_os = "windows")]
+        unsafe {
+            windows::Win32::Media::timeBeginPeriod(1);
+        }
+        std::thread::sleep(duration);
+        #[cfg(target_os = "windows")]
+        unsafe {
+            windows::Win32::Media::timeEndPeriod(1);
+        }
     }
 }
 

--- a/autd3/Cargo.toml
+++ b/autd3/Cargo.toml
@@ -26,7 +26,7 @@ zerocopy = { workspace = true }
 spin_sleep = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
-windows = { version = "0.58.0", features = ["Win32_Media_Multimedia", "Win32_System_Threading", "Win32_Foundation"] }
+windows = { version = "0.58.0", features = ["Win32_Media_Multimedia", "Win32_System_Threading", "Win32_Foundation", "Win32_System_Threading", "Win32_Security"] }
 
 [features]
 default = []

--- a/autd3/src/controller/mod.rs
+++ b/autd3/src/controller/mod.rs
@@ -1,6 +1,6 @@
 mod builder;
 mod group;
-mod timer;
+pub mod timer;
 
 use crate::{error::AUTDError, gain::Null, link::nop::Nop, prelude::Static};
 
@@ -24,7 +24,6 @@ use tracing;
 
 pub use builder::ControllerBuilder;
 pub use group::GroupGuard;
-pub use timer::{AsyncSleeper, SpinSleeper, TimerStrategy};
 
 use derive_more::{Deref, DerefMut};
 
@@ -279,7 +278,7 @@ mod tests {
     // GRCOV_EXCL_STOP
 
     #[rstest::rstest]
-    #[case(TimerStrategy::Std)]
+    #[case(TimerStrategy::Std(StdSleeper::default()))]
     #[case(TimerStrategy::Spin(SpinSleeper::default()))]
     #[case(TimerStrategy::Async(AsyncSleeper::default()))]
     #[tokio::test(flavor = "multi_thread")]

--- a/autd3/src/controller/mod.rs
+++ b/autd3/src/controller/mod.rs
@@ -262,8 +262,9 @@ mod tests {
         derive::{Gain, GainContext, GainContextGenerator, Segment},
         geometry::Vector3,
     };
+
     use spin_sleep::SpinSleeper;
-    use timer::{AsyncSleeper, StdSleeper, TimerStrategy, WaitableSleeper};
+    use timer::*;
 
     use crate::{link::Audit, prelude::*};
 
@@ -283,8 +284,7 @@ mod tests {
     #[case(TimerStrategy::Std(StdSleeper::default()))]
     #[case(TimerStrategy::Spin(SpinSleeper::default()))]
     #[case(TimerStrategy::Async(AsyncSleeper::default()))]
-    #[cfg(target_os = "windows")]
-    #[case(TimerStrategy::Waitable(WaitableSleeper::new().unwrap()))]
+    #[cfg_attr(target_os = "windows", case(TimerStrategy::Waitable(WaitableSleeper::new().unwrap())))]
     #[tokio::test(flavor = "multi_thread")]
     async fn open_with_timer(#[case] strategy: TimerStrategy) {
         assert!(Controller::builder([AUTD3::new(Vector3::zeros())])

--- a/autd3/src/controller/mod.rs
+++ b/autd3/src/controller/mod.rs
@@ -262,6 +262,8 @@ mod tests {
         derive::{Gain, GainContext, GainContextGenerator, Segment},
         geometry::Vector3,
     };
+    use spin_sleep::SpinSleeper;
+    use timer::{AsyncSleeper, StdSleeper, TimerStrategy, WaitableSleeper};
 
     use crate::{link::Audit, prelude::*};
 
@@ -281,6 +283,8 @@ mod tests {
     #[case(TimerStrategy::Std(StdSleeper::default()))]
     #[case(TimerStrategy::Spin(SpinSleeper::default()))]
     #[case(TimerStrategy::Async(AsyncSleeper::default()))]
+    #[cfg(target_os = "windows")]
+    #[case(TimerStrategy::Waitable(WaitableSleeper::new().unwrap()))]
     #[tokio::test(flavor = "multi_thread")]
     async fn open_with_timer(#[case] strategy: TimerStrategy) {
         assert!(Controller::builder([AUTD3::new(Vector3::zeros())])

--- a/autd3/src/controller/timer/mod.rs
+++ b/autd3/src/controller/timer/mod.rs
@@ -17,8 +17,8 @@ use autd3_driver::{
 use instant::Instant;
 
 use itertools::Itertools;
-use sleep::StdSleeper;
-pub use sleep::{AsyncSleeper, Sleeper};
+use sleep::Sleeper;
+pub use sleep::{AsyncSleeper, StdSleeper};
 pub use spin_sleep::SpinSleeper;
 
 use crate::error::AUTDError;
@@ -26,7 +26,7 @@ use crate::error::AUTDError;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum TimerStrategy {
-    Std,
+    Std(StdSleeper),
     Spin(SpinSleeper),
     Async(AsyncSleeper),
 }
@@ -49,16 +49,9 @@ impl Timer {
         parallel: bool,
     ) -> Result<(), AUTDError> {
         match &self.strategy {
-            TimerStrategy::Std => {
+            TimerStrategy::Std(sleeper) => {
                 self._send(
-                    &StdSleeper {},
-                    geometry,
-                    tx,
-                    rx,
-                    link,
-                    operations,
-                    timeout,
-                    parallel,
+                    sleeper, geometry, tx, rx, link, operations, timeout, parallel,
                 )
                 .await
             }
@@ -241,7 +234,7 @@ mod tests {
     }
 
     #[rstest::rstest]
-    #[case(TimerStrategy::Std, StdSleeper {})]
+    #[case(TimerStrategy::Std(StdSleeper::default()), StdSleeper::default())]
     #[case(TimerStrategy::Spin(SpinSleeper::default()), SpinSleeper::default())]
     #[case(TimerStrategy::Async(AsyncSleeper::default()), AsyncSleeper::default())]
     #[tokio::test]
@@ -296,7 +289,7 @@ mod tests {
     }
 
     #[rstest::rstest]
-    #[case(TimerStrategy::Std, StdSleeper {})]
+    #[case(TimerStrategy::Std(StdSleeper::default()), StdSleeper::default())]
     #[case(TimerStrategy::Spin(SpinSleeper::default()), SpinSleeper::default())]
     #[case(TimerStrategy::Async(AsyncSleeper::default()), AsyncSleeper::default())]
     #[tokio::test]

--- a/autd3/src/controller/timer/mod.rs
+++ b/autd3/src/controller/timer/mod.rs
@@ -248,8 +248,7 @@ mod tests {
     #[case(TimerStrategy::Std(StdSleeper::default()), StdSleeper::default())]
     #[case(TimerStrategy::Spin(SpinSleeper::default()), SpinSleeper::default())]
     #[case(TimerStrategy::Async(AsyncSleeper::default()), AsyncSleeper::default())]
-    #[cfg(target_os = "windows")]
-    #[case(TimerStrategy::Waitable(WaitableSleeper::new().unwrap()), WaitableSleeper::new().unwrap())]
+    #[cfg_attr(target_os = "windows", case(TimerStrategy::Waitable(WaitableSleeper::new().unwrap()), WaitableSleeper::new().unwrap()))]
     #[tokio::test]
     async fn test_send_receive(#[case] strategy: TimerStrategy, #[case] sleeper: impl Sleeper) {
         let mut link = MockLink {
@@ -305,8 +304,7 @@ mod tests {
     #[case(TimerStrategy::Std(StdSleeper::default()), StdSleeper::default())]
     #[case(TimerStrategy::Spin(SpinSleeper::default()), SpinSleeper::default())]
     #[case(TimerStrategy::Async(AsyncSleeper::default()), AsyncSleeper::default())]
-    #[cfg(target_os = "windows")]
-    #[case(TimerStrategy::Waitable(WaitableSleeper::new().unwrap()), WaitableSleeper::new().unwrap())]
+    #[cfg_attr(target_os = "windows", case(TimerStrategy::Waitable(WaitableSleeper::new().unwrap()), WaitableSleeper::new().unwrap()))]
     #[tokio::test]
     async fn test_wait_msg_processed(
         #[case] strategy: TimerStrategy,

--- a/autd3/src/controller/timer/sleep.rs
+++ b/autd3/src/controller/timer/sleep.rs
@@ -29,7 +29,7 @@ impl Sleeper for SpinSleeper {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AsyncSleeper {
     #[cfg(target_os = "windows")]
-    timer_resolution: Option<std::num::NonZeroU32>,
+    pub timer_resolution: Option<std::num::NonZeroU32>,
 }
 
 impl Sleeper for AsyncSleeper {

--- a/autd3/src/controller/timer/sleep.rs
+++ b/autd3/src/controller/timer/sleep.rs
@@ -77,3 +77,79 @@ impl Default for AsyncSleeper {
         }
     }
 }
+
+#[cfg(target_os = "windows")]
+pub use win::WaitableSleeper;
+
+#[cfg(target_os = "windows")]
+mod win {
+    use super::Sleeper;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct WaitableSleeper {
+        handle: windows::Win32::Foundation::HANDLE,
+    }
+
+    impl WaitableSleeper {
+        pub fn new() -> windows::core::Result<Self> {
+            Ok(Self {
+                handle: unsafe {
+                    windows::Win32::System::Threading::CreateWaitableTimerExW(
+                        None,
+                        None,
+                        windows::Win32::System::Threading::CREATE_WAITABLE_TIMER_HIGH_RESOLUTION,
+                        windows::Win32::System::Threading::TIMER_ALL_ACCESS.0,
+                    )?
+                },
+            })
+        }
+    }
+
+    impl Sleeper for WaitableSleeper {
+        type Instant = std::time::Instant;
+
+        async fn sleep_until(&self, deadline: Self::Instant) {
+            unsafe {
+                let time = deadline - std::time::Instant::now();
+                if time.is_zero() {
+                    return;
+                }
+                let duetime = (time.as_nanos() / 100) as i64;
+                let duetime = -duetime;
+                let set_and_wait = || {
+                    if let Err(e) = windows::Win32::System::Threading::SetWaitableTimer(
+                        self.handle,
+                        &duetime,
+                        0,
+                        None,
+                        None,
+                        false,
+                    ) {
+                        tracing::warn!(
+                            "SetWaitableTimer failed: {:?}, fallback to std::thread::sleep...",
+                            e
+                        );
+                        return false;
+                    }
+                    if windows::Win32::System::Threading::WaitForSingleObject(
+                        self.handle,
+                        windows::Win32::System::Threading::INFINITE,
+                    ) == windows::Win32::Foundation::WAIT_FAILED
+                    {
+                        tracing::warn!(
+                            "WaitForSingleObject failed: {:?}, fallback to std::thread::sleep...",
+                            windows::Win32::Foundation::GetLastError()
+                        );
+                        return false;
+                    }
+                    true
+                };
+                if !set_and_wait() {
+                    windows::Win32::Media::timeBeginPeriod(1);
+                    std::thread::sleep(time);
+                    windows::Win32::Media::timeEndPeriod(1);
+                }
+            }
+        }
+    }
+}

--- a/autd3/src/prelude.rs
+++ b/autd3/src/prelude.rs
@@ -1,8 +1,5 @@
 pub use crate::{
-    controller::{
-        timer::{AsyncSleeper, SpinSleeper, StdSleeper, TimerStrategy},
-        Controller,
-    },
+    controller::Controller,
     datagram::{
         gain::{Bessel, Focus, Group, IntoGainCache, Null, Plane, Uniform},
         modulation::{IntoFir, IntoModulationCache, IntoRadiationPressure, Sine, Square, Static},

--- a/autd3/src/prelude.rs
+++ b/autd3/src/prelude.rs
@@ -1,5 +1,8 @@
 pub use crate::{
-    controller::{AsyncSleeper, Controller, SpinSleeper, TimerStrategy},
+    controller::{
+        timer::{AsyncSleeper, SpinSleeper, StdSleeper, TimerStrategy},
+        Controller,
+    },
     datagram::{
         gain::{Bessel, Focus, Group, IntoGainCache, Null, Plane, Uniform},
         modulation::{IntoFir, IntoModulationCache, IntoRadiationPressure, Sine, Square, Static},


### PR DESCRIPTION
- **make `AsyncSleeper::timer_resolution` public**
- **make `ProcessPriority` visible on non-Windows**
- **fmt**
- **Improve sleep precision on Windows with `StdSleep`**
- **make `SOEM::sync0_cycle, send_cycle` Duration**
- **add `TimerStrategy::Waitable` on Windows**
- **bump to v29.0.3-alpha.3**
