### PR TITLE
bump to v29.0.0-rc.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "29.0.0-rc.7"
+version = "29.0.0-rc.8"
 authors = ["shun suzuki <suzuki@hapis.k.u-tokyo.ac.jp>"]
 edition = "2021"
 license = "MIT"
@@ -63,12 +63,12 @@ csv = "1.3.0"
 seq-macro = "0.3.5"
 spin_sleep = "1.2.1"
 zerocopy = { version = "0.8.6", features = ["derive"] }
-autd3 = { path = "./autd3", version = "29.0.0-rc.7" }
-autd3-driver = { path = "./autd3-driver", version = "29.0.0-rc.7" }
-autd3-derive = { path = "./autd3-derive", version = "29.0.0-rc.7" }
-autd3-gain-holo = { path = "./autd3-gain-holo", version = "29.0.0-rc.7" }
-autd3-link-simulator = { path = "./autd3-link-simulator", version = "29.0.0-rc.7" }
-autd3-link-twincat = { path = "./autd3-link-twincat", version = "29.0.0-rc.7" }
-autd3-modulation-audio-file = { path = "./autd3-modulation-audio-file", version = "29.0.0-rc.7" }
-autd3-firmware-emulator = { path = "./autd3-firmware-emulator", version = "29.0.0-rc.7" }
-autd3-protobuf = { path = "./autd3-protobuf", version = "29.0.0-rc.7" }
+autd3 = { path = "./autd3", version = "29.0.0-rc.8" }
+autd3-driver = { path = "./autd3-driver", version = "29.0.0-rc.8" }
+autd3-derive = { path = "./autd3-derive", version = "29.0.0-rc.8" }
+autd3-gain-holo = { path = "./autd3-gain-holo", version = "29.0.0-rc.8" }
+autd3-link-simulator = { path = "./autd3-link-simulator", version = "29.0.0-rc.8" }
+autd3-link-twincat = { path = "./autd3-link-twincat", version = "29.0.0-rc.8" }
+autd3-modulation-audio-file = { path = "./autd3-modulation-audio-file", version = "29.0.0-rc.8" }
+autd3-firmware-emulator = { path = "./autd3-firmware-emulator", version = "29.0.0-rc.8" }
+autd3-protobuf = { path = "./autd3-protobuf", version = "29.0.0-rc.8" }

--- a/autd3-driver/src/ethercat/dc_sys_time.rs
+++ b/autd3-driver/src/ethercat/dc_sys_time.rs
@@ -5,6 +5,7 @@ use crate::derive::AUTDInternalError;
 use super::ECAT_DC_SYS_TIME_BASE;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(C)]
 pub struct DcSysTime {
     dc_sys_time: u64,
 }


### PR DESCRIPTION
- **make `DcSysTime` `#[repr(C)]`**
- **bump to v29.0.0-rc.8**
