### PR TITLE
v29

### DIFF
--- a/autd3-firmware-emulator/tests/op/info.rs
+++ b/autd3-firmware-emulator/tests/op/info.rs
@@ -32,18 +32,19 @@ fn send_firminfo() -> anyhow::Result<()> {
     }
 
     send(&mut cpu, CPUMajor, &geometry, &mut tx)?;
-    assert_eq!(FirmwareVersion::LATEST_VERSION_NUM_MAJOR, cpu.rx().data());
+    assert_eq!(FirmwareVersion::LATEST_VERSION_NUM_MAJOR.0, cpu.rx().data());
     assert!(!cpu.reads_fpga_state());
 
     send(&mut cpu, CPUMinor, &geometry, &mut tx)?;
-    assert_eq!(FirmwareVersion::LATEST_VERSION_NUM_MINOR, cpu.rx().data());
+    assert_eq!(FirmwareVersion::LATEST_VERSION_NUM_MINOR.0, cpu.rx().data());
     assert!(!cpu.reads_fpga_state());
 
     send(&mut cpu, FPGAMajor, &geometry, &mut tx)?;
+    assert_eq!(FirmwareVersion::LATEST_VERSION_NUM_MAJOR.0, cpu.rx().data());
     assert!(!cpu.reads_fpga_state());
 
     send(&mut cpu, FPGAMinor, &geometry, &mut tx)?;
-    assert_eq!(FirmwareVersion::LATEST_VERSION_NUM_MINOR, cpu.rx().data());
+    assert_eq!(FirmwareVersion::LATEST_VERSION_NUM_MINOR.0, cpu.rx().data());
     assert!(!cpu.reads_fpga_state());
 
     send(&mut cpu, FPGAFunctions, &geometry, &mut tx)?;

--- a/autd3-protobuf/src/lightweight/server.rs
+++ b/autd3-protobuf/src/lightweight/server.rs
@@ -233,11 +233,11 @@ where
                     firmware_version_list: list
                         .iter()
                         .map(|f| firmware_version_response_lightweight::FirmwareVersion {
-                            cpu_major_version: f.cpu_version_number_major() as _,
-                            cpu_minor_version: f.cpu_version_number_minor() as _,
-                            fpga_major_version: f.fpga_version_number_major() as _,
-                            fpga_minor_version: f.fpga_version_number_minor() as _,
-                            fpga_function_bits: f.fpga_function_bits() as _,
+                            cpu_major_version: f.cpu().major().0 as _,
+                            cpu_minor_version: f.cpu().minor().0 as _,
+                            fpga_major_version: f.fpga().major().0 as _,
+                            fpga_minor_version: f.fpga().minor().0 as _,
+                            fpga_function_bits: f.fpga().function_bits() as _,
                         })
                         .collect(),
                 })),

--- a/autd3-protobuf/src/traits/driver/firmware/version.rs
+++ b/autd3-protobuf/src/traits/driver/firmware/version.rs
@@ -11,13 +11,56 @@ impl FromMessage<FirmwareVersionResponseLightweight>
             .map(|(i, v)| {
                 autd3_driver::firmware::version::FirmwareVersion::new(
                     i as _,
-                    v.cpu_major_version as _,
-                    v.cpu_minor_version as _,
-                    v.fpga_major_version as _,
-                    v.fpga_minor_version as _,
-                    v.fpga_function_bits as _,
+                    autd3_driver::firmware::version::CPUVersion::new(
+                        autd3_driver::firmware::version::Major(v.cpu_major_version as _),
+                        autd3_driver::firmware::version::Minor(v.cpu_minor_version as _),
+                    ),
+                    autd3_driver::firmware::version::FPGAVersion::new(
+                        autd3_driver::firmware::version::Major(v.fpga_major_version as _),
+                        autd3_driver::firmware::version::Minor(v.fpga_minor_version as _),
+                        v.fpga_function_bits as _,
+                    ),
                 )
             })
             .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn firmware_version() {
+        let firmware_versions = vec![autd3_driver::firmware::version::FirmwareVersion::new(
+            0,
+            autd3_driver::firmware::version::CPUVersion::new(
+                autd3_driver::firmware::version::Major(1),
+                autd3_driver::firmware::version::Minor(2),
+            ),
+            autd3_driver::firmware::version::FPGAVersion::new(
+                autd3_driver::firmware::version::Major(3),
+                autd3_driver::firmware::version::Minor(4),
+                5,
+            ),
+        )];
+        let response = FirmwareVersionResponseLightweight {
+            success: true,
+            msg: String::new(),
+            firmware_version_list: firmware_versions
+                .iter()
+                .map(|f| firmware_version_response_lightweight::FirmwareVersion {
+                    cpu_major_version: f.cpu().major().0 as _,
+                    cpu_minor_version: f.cpu().minor().0 as _,
+                    fpga_major_version: f.fpga().major().0 as _,
+                    fpga_minor_version: f.fpga().minor().0 as _,
+                    fpga_function_bits: f.fpga().function_bits() as _,
+                })
+                .collect(),
+        };
+        assert_eq!(
+            firmware_versions,
+            Vec::<autd3_driver::firmware::version::FirmwareVersion>::from_msg(&response).unwrap()
+        );
     }
 }

--- a/autd3/src/controller/builder.rs
+++ b/autd3/src/controller/builder.rs
@@ -77,12 +77,12 @@ impl ControllerBuilder {
     /// Opens a controller with a timeout.
     ///
     /// Opens link, and then initialize and synchronize the devices. The `timeout` is used to send data for initialization and synchronization.
-    #[tracing::instrument(level = "debug", skip(link_builder))]
     pub async fn open_with_timeout<B: LinkBuilder>(
         self,
         link_builder: B,
         timeout: Duration,
     ) -> Result<Controller<B::L>, AUTDError> {
+        tracing::debug!("Opening a controller: {:?} (timeout = {:?})", self, timeout);
         let geometry = Geometry::new(self.devices, self.default_parallel_threshold);
         Controller {
             link: link_builder.open(&geometry).await?,


### PR DESCRIPTION
- **rm `tracing::instrument` from `ControllerBuilder::open_with_timeout`**
- **refactor `FirmwareVersion`**
