### PR TITLE
v29

### DIFF
--- a/autd3-derive/src/builder.rs
+++ b/autd3-derive/src/builder.rs
@@ -93,8 +93,9 @@ fn impl_getter(input: &syn::DeriveInput) -> proc_macro2::TokenStream {
             if let syn::Type::Path(path) = ty {
                 let path = path.path.to_token_stream().to_string();
                 {
-                    let re = regex::Regex::new(r"^LazyCell < RefCell < (?<inner>[\w<>\s]+) > >$")
-                        .unwrap();
+                    let re =
+                        regex::Regex::new(r"^LazyCell < RefCell < (?<inner>[\d\w<>\s,]+) > >$")
+                            .unwrap();
                     if let Some(caps) = re.captures(&path) {
                         let inner: proc_macro2::TokenStream = caps["inner"].parse().unwrap();
                         let mut_name = format_ident!("{}_mut", ident);

--- a/autd3-driver/src/ethercat/dc_sys_time.rs
+++ b/autd3-driver/src/ethercat/dc_sys_time.rs
@@ -22,12 +22,10 @@ impl DcSysTime {
     }
 
     pub fn from_utc(utc: OffsetDateTime) -> Result<Self, AUTDInternalError> {
-        match (utc - ECAT_DC_SYS_TIME_BASE).whole_nanoseconds() {
-            i if i < 0 => Err(AUTDInternalError::InvalidDateTime),
-            i => Ok(Self {
-                dc_sys_time: i as u64,
-            }),
-        }
+        Ok(Self {
+            dc_sys_time: u64::try_from((utc - ECAT_DC_SYS_TIME_BASE).whole_nanoseconds())
+                .map_err(|_| AUTDInternalError::InvalidDateTime)?,
+        })
     }
 
     pub fn now() -> Self {
@@ -71,6 +69,7 @@ mod tests {
     #[case(Ok(DcSysTime { dc_sys_time: 1000000000 }), time::macros::datetime!(2000-01-01 0:0:1 UTC))]
     #[case(Ok(DcSysTime { dc_sys_time: 31622400000000000 }), time::macros::datetime!(2001-01-01 0:0:0 UTC))]
     #[case(Err(AUTDInternalError::InvalidDateTime), time::macros::datetime!(1999-01-01 0:0:1 UTC))]
+    #[case(Err(AUTDInternalError::InvalidDateTime), time::macros::datetime!(9999-01-01 0:0:1 UTC))]
     fn from_utc(#[case] expect: Result<DcSysTime, AUTDInternalError>, #[case] utc: OffsetDateTime) {
         assert_eq!(expect, DcSysTime::from_utc(utc));
     }

--- a/autd3-firmware-emulator/src/fpga/emulator/modulation.rs
+++ b/autd3-firmware-emulator/src/fpga/emulator/modulation.rs
@@ -43,10 +43,7 @@ impl FPGAEmulator {
     }
 
     pub fn modulation_at(&self, segment: Segment, idx: usize) -> u8 {
-        let m = match segment {
-            Segment::S0 => &self.mem.modulation_bram_0()[idx >> 1],
-            Segment::S1 => &self.mem.modulation_bram_1()[idx >> 1],
-        };
+        let m = &self.mem.modulation_bram()[&segment][idx >> 1];
         let m = if idx % 2 == 0 { m & 0xFF } else { m >> 8 };
         m as u8
     }
@@ -105,8 +102,14 @@ mod tests {
     #[test]
     fn modulation() {
         let fpga = FPGAEmulator::new(249);
-        fpga.mem.modulation_bram_0_mut()[0] = 0x1234;
-        fpga.mem.modulation_bram_0_mut()[1] = 0x5678;
+        fpga.mem
+            .modulation_bram_mut()
+            .get_mut(&Segment::S0)
+            .unwrap()[0] = 0x1234;
+        fpga.mem
+            .modulation_bram_mut()
+            .get_mut(&Segment::S0)
+            .unwrap()[1] = 0x5678;
         fpga.mem.controller_bram_mut()[ADDR_MOD_CYCLE0] = 3 - 1;
         assert_eq!(3, fpga.modulation_cycle(Segment::S0));
         assert_eq!(0x34, fpga.modulation());

--- a/autd3-firmware-emulator/src/fpga/emulator/stm/foci.rs
+++ b/autd3-firmware-emulator/src/fpga/emulator/stm/foci.rs
@@ -36,10 +36,7 @@ impl FPGAEmulator {
     }
 
     pub(crate) fn foci_stm_drives_inplace(&self, segment: Segment, idx: usize, dst: &mut [Drive]) {
-        let bram = match segment {
-            Segment::S0 => self.mem.stm_bram_0(),
-            Segment::S1 => self.mem.stm_bram_1(),
-        };
+        let bram = &self.mem.stm_bram()[&segment];
         let sound_speed = self.sound_speed(segment);
 
         self.mem

--- a/autd3-firmware-emulator/src/fpga/emulator/stm/gain.rs
+++ b/autd3-firmware-emulator/src/fpga/emulator/stm/gain.rs
@@ -7,20 +7,17 @@ use crate::FPGAEmulator;
 
 impl FPGAEmulator {
     pub(crate) fn gain_stm_drives_inplace(&self, segment: Segment, idx: usize, dst: &mut [Drive]) {
-        match segment {
-            Segment::S0 => self.mem.stm_bram_0(),
-            Segment::S1 => self.mem.stm_bram_1(),
-        }
-        .iter()
-        .skip(256 * idx)
-        .zip(self.phase_correction().iter())
-        .take(self.mem.num_transducers)
-        .enumerate()
-        .for_each(|(i, (&d, &p))| {
-            dst[i] = Drive::new(
-                Phase::new((d & 0xFF) as u8) + p,
-                EmitIntensity::new(((d >> 8) & 0xFF) as u8),
-            )
-        })
+        self.mem.stm_bram()[&segment]
+            .iter()
+            .skip(256 * idx)
+            .zip(self.phase_correction().iter())
+            .take(self.mem.num_transducers)
+            .enumerate()
+            .for_each(|(i, (&d, &p))| {
+                dst[i] = Drive::new(
+                    Phase::new((d & 0xFF) as u8) + p,
+                    EmitIntensity::new(((d >> 8) & 0xFF) as u8),
+                )
+            })
     }
 }

--- a/autd3-link-twincat/src/local/mod.rs
+++ b/autd3-link-twincat/src/local/mod.rs
@@ -45,24 +45,13 @@ impl LinkBuilder for TwinCATBuilder {
     type L = TwinCAT;
 
     async fn open(self, _: &Geometry) -> Result<Self::L, AUTDInternalError> {
-        let dll = match unsafe { lib::Library::new("TcAdsDll") } {
-            Ok(dll) => dll,
-            Err(_) => {
-                return Err(AUTDInternalError::LinkError(
-                    "TcAdsDll not found. Please install TwinCAT3".to_owned(),
-                ))
-            }
-        };
-
+        let dll = unsafe { lib::Library::new("TcAdsDll") }.map_err(|_| {
+            AUTDInternalError::LinkError("TcAdsDll not found. Please install TwinCAT3".to_owned())
+        })?;
         let port = unsafe {
-            match dll.get::<unsafe extern "C" fn() -> i32>(b"AdsPortOpenEx") {
-                Ok(f) => f(),
-                Err(_) => {
-                    return Err(AUTDInternalError::LinkError(
-                        "AdsPortOpenEx not found".to_owned(),
-                    ))
-                }
-            }
+            dll.get::<unsafe extern "C" fn() -> i32>(b"AdsPortOpenEx")
+                .map_err(|_| AUTDInternalError::LinkError("AdsPortOpenEx not found".to_owned()))?(
+            )
         };
         if port == 0 {
             return Err(AdsError::OpenPort.into());
@@ -70,15 +59,10 @@ impl LinkBuilder for TwinCATBuilder {
 
         let mut ams_addr: AmsAddr = unsafe { std::mem::zeroed() };
         let n_err = unsafe {
-            match dll.get::<unsafe extern "C" fn(i32, *mut AmsAddr) -> i32>(b"AdsGetLocalAddressEx")
-            {
-                Ok(f) => f(port, &mut ams_addr as *mut _),
-                Err(_) => {
-                    return Err(AUTDInternalError::LinkError(
-                        "AdsGetLocalAddressEx not found".to_owned(),
-                    ))
-                }
-            }
+            dll.get::<unsafe extern "C" fn(i32, *mut AmsAddr) -> i32>(b"AdsGetLocalAddressEx")
+                .map_err(|_| {
+                    AUTDInternalError::LinkError("AdsGetLocalAddressEx not found".to_owned())
+                })?(port, &mut ams_addr as *mut _)
         };
         if n_err != 0 {
             return Err(AdsError::GetLocalAddress(n_err).into());
@@ -105,17 +89,11 @@ impl TwinCAT {
 impl Link for TwinCAT {
     async fn close(&mut self) -> Result<(), AUTDInternalError> {
         unsafe {
-            match self
-                .dll
+            self.dll
                 .get::<unsafe extern "C" fn(i32) -> i32>(b"AdsPortCloseEx")
-            {
-                Ok(f) => f(self.port),
-                Err(_) => {
-                    return Err(AUTDInternalError::LinkError(
-                        "AdsPortCloseEx not found".to_owned(),
-                    ))
-                }
-            };
+                .map_err(|_| AUTDInternalError::LinkError("AdsPortCloseEx not found".to_owned()))?(
+                self.port,
+            );
         }
         self.port = 0;
         Ok(())
@@ -123,29 +101,26 @@ impl Link for TwinCAT {
 
     async fn send(&mut self, tx: &[TxMessage]) -> Result<bool, AUTDInternalError> {
         unsafe {
-            let n_err = match self.dll.get::<unsafe extern "C" fn(
+            let n_err = self.dll.get::<unsafe extern "C" fn(
                 i32,
                 *const AmsAddr,
                 u32,
                 u32,
                 u32,
                 *const c_void,
-            ) -> i32>(b"AdsSyncWriteReqEx")
-            {
-                Ok(f) => f(
+            ) -> i32>(b"AdsSyncWriteReqEx").map_err(|_|
+                AUTDInternalError::LinkError(
+                    "AdsSyncWriteReqEx not found".to_owned(),
+                )
+            )?
+            (
                     self.port,
                     &raw const self.send_addr,
                     INDEX_GROUP,
                     INDEX_OFFSET_BASE,
                     tx.as_bytes().len() as _,
                     tx.as_ptr() as _,
-                ),
-                Err(_) => {
-                    return Err(AUTDInternalError::LinkError(
-                        "AdsSyncWriteReqEx not found".to_owned(),
-                    ))
-                }
-            };
+            );
 
             if n_err > 0 {
                 Err(AdsError::SendData(n_err).into())
@@ -158,31 +133,28 @@ impl Link for TwinCAT {
     async fn receive(&mut self, rx: &mut [RxMessage]) -> Result<bool, AUTDInternalError> {
         let mut read_bytes: u32 = 0;
         unsafe {
-            let n_err = match self.dll.get::<unsafe extern "C" fn(
-                i32,
-                *const AmsAddr,
-                u32,
-                u32,
-                u32,
-                *mut c_void,
-                *mut u32,
-            ) -> i32>(b"AdsSyncReadReqEx2")
-            {
-                Ok(f) => f(
-                    self.port,
-                    &raw const self.send_addr,
-                    INDEX_GROUP,
-                    INDEX_OFFSET_BASE_READ,
-                    std::mem::size_of_val(rx) as _,
-                    rx.as_mut_ptr() as *mut c_void,
-                    &mut read_bytes as *mut u32,
-                ),
-                Err(_) => {
-                    return Err(AUTDInternalError::LinkError(
-                        "AdsSyncReadReqEx2 not found".to_owned(),
-                    ))
-                }
-            };
+            let n_err = self
+                .dll
+                .get::<unsafe extern "C" fn(
+                    i32,
+                    *const AmsAddr,
+                    u32,
+                    u32,
+                    u32,
+                    *mut c_void,
+                    *mut u32,
+                ) -> i32>(b"AdsSyncReadReqEx2")
+                .map_err(|_| {
+                    AUTDInternalError::LinkError("AdsSyncReadReqEx2 not found".to_owned())
+                })?(
+                self.port,
+                &raw const self.send_addr,
+                INDEX_GROUP,
+                INDEX_OFFSET_BASE_READ,
+                std::mem::size_of_val(rx) as _,
+                rx.as_mut_ptr() as *mut c_void,
+                &mut read_bytes as *mut u32,
+            );
 
             if n_err > 0 {
                 Err(AdsError::ReadData(n_err).into())

--- a/autd3-protobuf/src/lightweight/server.rs
+++ b/autd3-protobuf/src/lightweight/server.rs
@@ -91,7 +91,7 @@ where
         let transition_mode = gain
             .transition_mode
             .as_ref()
-            .map(|mode| autd3_driver::firmware::fpga::TransitionMode::from_msg(mode))
+            .map(autd3_driver::firmware::fpga::TransitionMode::from_msg)
             .transpose()?;
         Ok(g.with_segment(segment, transition_mode))
     }
@@ -149,7 +149,7 @@ where
         let transition_mode = modulation
             .transition_mode
             .as_ref()
-            .map(|mode| autd3_driver::firmware::fpga::TransitionMode::from_msg(mode))
+            .map(autd3_driver::firmware::fpga::TransitionMode::from_msg)
             .transpose()?;
         Ok(m.with_segment(segment, transition_mode))
     }
@@ -405,7 +405,7 @@ where
                     let transition_mode = msg
                         .transition_mode
                         .as_ref()
-                        .map(|mode| autd3_driver::firmware::fpga::TransitionMode::from_msg(mode))
+                        .map(autd3_driver::firmware::fpga::TransitionMode::from_msg)
                         .transpose()?;
                     seq_macro::seq!(K in 1..=8 {
                         match inner.inner {

--- a/autd3-protobuf/src/traits/driver/datagram/segment.rs
+++ b/autd3-protobuf/src/traits/driver/datagram/segment.rs
@@ -41,11 +41,7 @@ impl ToMessage for autd3_driver::datagram::SwapSegment {
 
 impl FromMessage<SwapSegment> for autd3_driver::datagram::SwapSegment {
     fn from_msg(msg: &SwapSegment) -> Result<Self, AUTDProtoBufError> {
-        let inner = msg
-            .inner
-            .as_ref()
-            .ok_or(AUTDProtoBufError::DataParseError)?;
-        Ok(match inner {
+        Ok(match msg.inner.ok_or(AUTDProtoBufError::DataParseError)? {
             swap_segment::Inner::Gain(inner) => {
                 let mode = inner
                     .transition_mode

--- a/autd3-protobuf/src/traits/driver/datagram/stm/gain.rs
+++ b/autd3-protobuf/src/traits/driver/datagram/stm/gain.rs
@@ -18,9 +18,9 @@ where
             loop_behavior: Some(self.loop_behavior().to_msg(None)),
             gains: self
                 .iter()
-                .filter_map(|g| match g.to_msg(None).datagram {
-                    Some(datagram::Datagram::Gain(gain)) => Some(gain),
-                    _ => None,
+                .map(|g| match g.to_msg(None).datagram {
+                    Some(datagram::Datagram::Gain(gain)) => gain,
+                    _ => unreachable!(),
                 })
                 .collect(),
             mode: Some(self.mode() as _),

--- a/autd3-protobuf/src/traits/driver/defined/angle.rs
+++ b/autd3-protobuf/src/traits/driver/defined/angle.rs
@@ -16,10 +16,8 @@ impl ToMessage for autd3_driver::defined::Angle {
 
 impl FromMessage<Option<Angle>> for autd3_driver::defined::Angle {
     fn from_msg(msg: &Option<Angle>) -> Result<Self, AUTDProtoBufError> {
-        match msg {
-            None => Err(AUTDProtoBufError::DataParseError),
-            Some(msg) => Ok(msg.rad * autd3_driver::defined::rad),
-        }
+        msg.map(|msg| msg.rad * autd3_driver::defined::rad)
+            .ok_or(AUTDProtoBufError::DataParseError)
     }
 }
 

--- a/autd3-protobuf/src/traits/driver/firmware/fpga/transition_mode.rs
+++ b/autd3-protobuf/src/traits/driver/firmware/fpga/transition_mode.rs
@@ -37,8 +37,7 @@ impl ToMessage for autd3_driver::firmware::fpga::TransitionMode {
 
 impl FromMessage<TransitionMode> for autd3_driver::firmware::fpga::TransitionMode {
     fn from_msg(msg: &TransitionMode) -> Result<Self, AUTDProtoBufError> {
-        let mode = msg.mode.as_ref().ok_or(AUTDProtoBufError::DataParseError)?;
-        Ok(match *mode {
+        Ok(match msg.mode.ok_or(AUTDProtoBufError::DataParseError)? {
             transition_mode::Mode::SyncIdx(TransitionModeSyncIdx {}) => {
                 autd3_driver::firmware::fpga::TransitionMode::SyncIdx
             }

--- a/autd3-protobuf/src/traits/holo/amp.rs
+++ b/autd3-protobuf/src/traits/holo/amp.rs
@@ -16,10 +16,8 @@ impl ToMessage for autd3_gain_holo::Amplitude {
 
 impl FromMessage<Option<Amplitude>> for autd3_gain_holo::Amplitude {
     fn from_msg(msg: &Option<Amplitude>) -> Result<Self, AUTDProtoBufError> {
-        match msg {
-            Some(msg) => Ok(msg.value * autd3_gain_holo::Pa),
-            None => Err(AUTDProtoBufError::DataParseError),
-        }
+        msg.map(|msg| msg.value * autd3_gain_holo::Pa)
+            .ok_or(AUTDProtoBufError::DataParseError)
     }
 }
 

--- a/autd3-protobuf/src/traits/holo/nls/lm.rs
+++ b/autd3-protobuf/src/traits/holo/nls/lm.rs
@@ -84,7 +84,7 @@ mod tests {
     use rand::Rng;
 
     #[test]
-    fn test_holo_sdp() {
+    fn test_holo_lm() {
         let mut rng = rand::thread_rng();
 
         let holo = autd3_gain_holo::LM::new(

--- a/autd3/src/datagram/gain/group.rs
+++ b/autd3/src/datagram/gain/group.rs
@@ -56,6 +56,7 @@ where
     /// Returns [`AUTDInternalError::KeyIsAlreadyUsed`] if the `key` is already used previous [`Group::set`].
     ///
     /// [`AUTDInternalError::KeyIsAlreadyUsed`]: autd3_driver::error::AUTDInternalError::KeyIsAlreadyUsed
+    #[allow(clippy::map_entry)] // https://github.com/rust-lang/rust-clippy/issues/9925
     pub fn set(mut self, key: K, gain: impl IntoBoxedGain) -> Result<Self, AUTDInternalError> {
         if self.gain_map.contains_key(&key) {
             return Err(AUTDInternalError::KeyIsAlreadyUsed(format!("{:?}", key)));

--- a/examples/src/tests/flag.rs
+++ b/examples/src/tests/flag.rs
@@ -31,17 +31,13 @@ pub async fn flag(autd: &mut Controller<impl Link>) -> anyhow::Result<bool> {
         let states = autd.fpga_state().await?;
         println!("{} FPGA Status...", prompts[idx / 1000 % prompts.len()]);
         idx += 1;
-        states
-            .iter()
-            .enumerate()
-            .for_each(|(i, state)| match state {
-                Some(state) => {
-                    println!("\x1b[0K[{}]: thermo = {}", i, state.is_thermal_assert())
-                }
-                None => {
-                    println!("\x1b[0K[{}]: -", i);
-                }
-            });
+        states.iter().enumerate().for_each(|(i, state)| {
+            println!(
+                "\x1b[0K[{}]: thermo = {}",
+                i,
+                state.map_or_else(|| "-".to_string(), |s| s.is_thermal_assert().to_string())
+            );
+        });
         print!("\x1b[{}A", states.len() + 1);
     }
     print!("\x1b[1F\x1b[0J");

--- a/examples/src/tests/holo.rs
+++ b/examples/src/tests/holo.rs
@@ -35,10 +35,12 @@ pub async fn holo(autd: &mut Controller<impl Link>) -> anyhow::Result<bool> {
 
     let mut s = String::new();
     io::stdin().read_line(&mut s)?;
-    let idx = match s.trim().parse::<usize>() {
-        Ok(i) if i < gains.len() => i,
-        _ => 1,
-    };
+    let idx = s
+        .trim()
+        .parse::<usize>()
+        .ok()
+        .filter(|&i| i < gains.len())
+        .unwrap_or(1);
 
     let m = Sine::new(150. * Hz);
     let g = gains.swap_remove(idx).1;


### PR DESCRIPTION
- **refactor `Group` struct to remove unnecessary `Clone` bound on key type**
- **validate `DcSysTime::from_utc` method to check for u64 range**
- **refactor `Memory`**
- **allow `clippy::map_entry` caused by misdetection**
- **refactor `TwinCATBuilder`**
- **refactor `autd3-protobuf`**
- **refactor examples**
