### PR TITLE
bump to v29.0.0-rc.20

### DIFF
--- a/autd3-link-twincat/src/lib.rs
+++ b/autd3-link-twincat/src/lib.rs
@@ -20,4 +20,4 @@ pub use local::TwinCAT;
 
 #[cfg_attr(docsrs, doc(cfg(feature = "remote")))]
 #[cfg(feature = "remote")]
-pub use remote::RemoteTwinCAT;
+pub use remote::{RemoteTwinCAT, RemoteTwinCATOption};

--- a/autd3/src/datagram/gain/mod.rs
+++ b/autd3/src/datagram/gain/mod.rs
@@ -9,7 +9,7 @@ mod uniform;
 
 pub use autd3_driver::datagram::IntoBoxedGain;
 pub use bessel::{Bessel, BesselOption};
-pub use cache::Cache as GainCache;
+pub use cache::Cache;
 pub use custom::Custom;
 pub use focus::{Focus, FocusOption};
 pub use group::Group;

--- a/autd3/src/datagram/modulation/mod.rs
+++ b/autd3/src/datagram/modulation/mod.rs
@@ -10,7 +10,7 @@ mod square;
 mod r#static;
 
 pub use autd3_driver::datagram::IntoBoxedModulation;
-pub use cache::Cache as ModulationCache;
+pub use cache::Cache;
 pub use custom::Custom;
 pub use fir::Fir;
 pub use fourier::{Fourier, FourierOption};

--- a/autd3/src/prelude.rs
+++ b/autd3/src/prelude.rs
@@ -1,10 +1,14 @@
 pub use crate::{
     controller::{Controller, ParallelMode, SenderOption, SpinSleeper},
     datagram::{
+        gain::Cache as GainCache,
         gain::{
             Bessel, BesselOption, Focus, FocusOption, Group, Null, Plane, PlaneOption, Uniform,
         },
-        modulation::{FourierOption, Sine, SineOption, Square, SquareOption, Static},
+        modulation::Cache as ModulationCache,
+        modulation::{
+            Fir, FourierOption, RadiationPressure, Sine, SineOption, Square, SquareOption, Static,
+        },
         stm::{Circle, Line},
     },
     error::AUTDError,
@@ -18,7 +22,7 @@ pub use autd3_driver::{
     datagram::{
         Clear, ControlPoint, ControlPoints, DebugSettings, FixedUpdateRate, FociSTM, ForceFan,
         GainSTM, GainSTMOption, PhaseCorrection, PulseWidthEncoder, ReadsFPGAState, Silencer,
-        SwapSegment,
+        SwapSegment, WithLoopBehavior, WithSegment,
     },
     defined::{deg, kHz, mm, rad, ultrasound_freq, Hz, PI},
     error::AUTDDriverError,


### PR DESCRIPTION
- **update prelude**
- **exports `RemoteTwinCATOption`**
- **update deps**
