### PR TITLE
bump to v31.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Remove `Device::translate`, `Device::translate_to`, `Device::rotate`, `Device::rotate_to`, and `Device::affine`
   - Add `Geometry::reconfigure` instead
+- Rename from `DebugSettings` to `GPIOOutputs`
 - impl `Deref<Target = Geometry>` for `LightweightClient`
 
 # 30.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
-# 30.1.0
+# 31.0.0
 
+- Remove `Device::translate`, `Device::translate_to`, `Device::rotate`, `Device::rotate_to`, and `Device::affine`
+  - Add `Geometry::reconfigure` instead
 - impl `Deref<Target = Geometry>` for `LightweightClient`
 
 # 30.0.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "30.0.1"
+version = "31.0.0"
 authors = ["shun suzuki <suzuki@hapis.k.u-tokyo.ac.jp>"]
 edition = "2024"
 license = "MIT"
@@ -25,18 +25,18 @@ repository = "https://github.com/shinolab/autd3-rs"
 keywords = ["autd"]
 
 [workspace.dependencies]
-zerocopy = { version = "0.8.20", default-features = false }
-anyhow = { version = "1.0.96", default-features = false }
-async-trait = { version = "0.1.86", default-features = false }
+zerocopy = { version = "0.8.21", default-features = false }
+anyhow = { version = "1.0.97", default-features = false }
+async-trait = { version = "0.1.87", default-features = false }
 bitfield-struct = { version = "0.10.1", default-features = false }
-bitflags = { version = "2.8.0", default-features = false }
+bitflags = { version = "2.9.0", default-features = false }
 bit-vec = { version = "0.8.0", default-features = false }
 bvh = { version = "0.11.0", default-features = false }
-cc = { version = "1.2.15", default-features = false }
+cc = { version = "1.2.16", default-features = false }
 color-print = { version = "0.3.7", default-features = false }
 const_fn = { version = "0.4.11", default-features = false }
 criterion = { version = "0.5.1", default-features = false }
-getset = { version = "0.1.4", default-features = false }
+getset = { version = "0.1.5", default-features = false }
 glob = { version = "0.3.2", default-features = false }
 hound = { version = "3.5.1", default-features = false }
 itertools = { version = "0.14.0", default-features = false }
@@ -44,16 +44,16 @@ libloading = { version = "0.8.6", default-features = false }
 nalgebra = { version = "0.33.2", default-features = false }
 num = { version = "0.4.3", default-features = false }
 paste = { version = "1.0.15", default-features = false }
-proc-macro2 = { version = "1.0.93", default-features = false }
+proc-macro2 = { version = "1.0.94", default-features = false }
 prost = { version = "0.13.5", default-features = false }
 quote = { version = "1.0.38", default-features = false }
 rand = { version = "0.9.0", default-features = false }
 rstest = { version = "0.25.0", default-features = false }
 serde = { version = "1.0.218", default-features = false }
 serde_json = { version = "1.0.139", default-features = false }
-syn = { version = "2.0.98", default-features = false }
+syn = { version = "2.0.99", default-features = false }
 tempfile = { version = "3.17.1", default-features = false }
-thiserror = { version = "2.0.11", default-features = false }
+thiserror = { version = "2.0.12", default-features = false }
 time = { version = "0.3.37", default-features = false }
 tokio = { version = "1.43.0", default-features = false }
 tokio-test = { version = "0.4.4", default-features = false }
@@ -70,13 +70,13 @@ csv = { version = "1.3.1", default-features = false }
 seq-macro = { version = "0.3.5", default-features = false }
 spin_sleep = { version = "1.3.0", default-features = false }
 windows = { version = "0.60.0", default-features = false }
-autd3 = { path = "./autd3", version = "30.0.1", default-features = false }
-autd3-core = { path = "./autd3-core", version = "30.0.1", default-features = false }
-autd3-driver = { path = "./autd3-driver", version = "30.0.1", default-features = false }
-autd3-derive = { path = "./autd3-derive", version = "30.0.1", default-features = false }
-autd3-gain-holo = { path = "./autd3-gain-holo", version = "30.0.1", default-features = false }
-autd3-link-simulator = { path = "./autd3-link-simulator", version = "30.0.1", default-features = false }
-autd3-link-twincat = { path = "./autd3-link-twincat", version = "30.0.1", default-features = false }
-autd3-modulation-audio-file = { path = "./autd3-modulation-audio-file", version = "30.0.1", default-features = false }
-autd3-firmware-emulator = { path = "./autd3-firmware-emulator", version = "30.0.1", default-features = false }
-autd3-protobuf = { path = "./autd3-protobuf", version = "30.0.1", default-features = false }
+autd3 = { path = "./autd3", version = "31.0.0", default-features = false }
+autd3-core = { path = "./autd3-core", version = "31.0.0", default-features = false }
+autd3-driver = { path = "./autd3-driver", version = "31.0.0", default-features = false }
+autd3-derive = { path = "./autd3-derive", version = "31.0.0", default-features = false }
+autd3-gain-holo = { path = "./autd3-gain-holo", version = "31.0.0", default-features = false }
+autd3-link-simulator = { path = "./autd3-link-simulator", version = "31.0.0", default-features = false }
+autd3-link-twincat = { path = "./autd3-link-twincat", version = "31.0.0", default-features = false }
+autd3-modulation-audio-file = { path = "./autd3-modulation-audio-file", version = "31.0.0", default-features = false }
+autd3-firmware-emulator = { path = "./autd3-firmware-emulator", version = "31.0.0", default-features = false }
+autd3-protobuf = { path = "./autd3-protobuf", version = "31.0.0", default-features = false }

--- a/autd3-core/src/acoustics/mod.rs
+++ b/autd3-core/src/acoustics/mod.rs
@@ -50,15 +50,11 @@ mod tests {
     #[rstest::fixture]
     fn tr() -> Transducer {
         let mut rng = rand::rng();
-        Transducer::new(
-            0,
-            0,
-            Point3::new(
-                rng.random_range(-100.0..100.0),
-                rng.random_range(-100.0..100.0),
-                rng.random_range(-100.0..100.0),
-            ),
-        )
+        Transducer::new(Point3::new(
+            rng.random_range(-100.0..100.0),
+            rng.random_range(-100.0..100.0),
+            rng.random_range(-100.0..100.0),
+        ))
     }
 
     #[rstest::fixture]
@@ -95,7 +91,7 @@ mod tests {
     #[rstest::rstest]
     #[test]
     fn test_propagate(tr: Transducer, rot: UnitQuaternion, target: Point3, sound_speed: f32) {
-        let mut device = Device::new(0, rot, vec![tr.clone()]);
+        let mut device = Device::new(rot, vec![tr.clone()]);
         device.sound_speed = sound_speed;
         let wavenumber = device.wavenumber();
         assert_complex_approx_eq!(

--- a/autd3-core/src/datagram/loop_behavior.rs
+++ b/autd3-core/src/datagram/loop_behavior.rs
@@ -2,7 +2,6 @@ use std::num::NonZeroU16;
 
 /// The behavior of the loop.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
-#[repr(C)]
 pub enum LoopBehavior {
     /// Infinite loop.
     Infinite,

--- a/autd3-core/src/defined/angle.rs
+++ b/autd3-core/src/defined/angle.rs
@@ -17,6 +17,14 @@ pub struct Angle {
 }
 
 impl Angle {
+    /// An angle of zero
+    pub const ZERO: Self = Self { radian: 0.0 };
+
+    /// An angle of π
+    pub const PI: Self = Self {
+        radian: std::f32::consts::PI,
+    };
+
     /// Returns the angle in radian
     #[must_use]
     pub const fn radian(self) -> f32 {

--- a/autd3-core/src/geometry/rotation.rs
+++ b/autd3-core/src/geometry/rotation.rs
@@ -16,6 +16,14 @@ macro_rules! make_euler_angle_intrinsic {
                 )*
             }
 
+            impl EulerAngleIntrinsic {
+                /// The rotation identity.
+                #[must_use]
+                pub const fn identity() -> Self {
+                    Self::XYZ(Angle::ZERO, Angle::ZERO, Angle::ZERO)
+                }
+            }
+
             impl From<EulerAngleIntrinsic> for UnitQuaternion {
                 fn from(angle: EulerAngleIntrinsic) -> Self {
                     match angle {
@@ -43,6 +51,14 @@ macro_rules! make_euler_angle_extrinsic {
                     #[doc = "euler angle."]
                     [<$first:upper $second:upper $third:upper>](Angle, Angle, Angle),
                 )*
+            }
+
+            impl EulerAngleExtrinsic {
+                /// The rotation identity.
+                #[must_use]
+                pub const fn identity() -> Self {
+                    Self::XYZ(Angle::ZERO, Angle::ZERO, Angle::ZERO)
+                }
             }
 
             impl From<EulerAngleExtrinsic> for UnitQuaternion {
@@ -144,5 +160,14 @@ mod tests {
     ) {
         let angle: UnitQuaternion = angle.into();
         assert_approx_eq_quat!(expected, angle);
+    }
+
+    #[rstest::rstest]
+    #[case(EulerAngleExtrinsic::identity())]
+    #[case(EulerAngleIntrinsic::identity())]
+    #[test]
+    fn identity(#[case] angle: impl Into<UnitQuaternion>) {
+        let angle: UnitQuaternion = angle.into();
+        assert_eq!(UnitQuaternion::identity(), angle);
     }
 }

--- a/autd3-core/src/geometry/rotation.rs
+++ b/autd3-core/src/geometry/rotation.rs
@@ -7,6 +7,7 @@ use paste::paste;
 macro_rules! make_euler_angle_intrinsic {
     ($({$first:ident, $second:ident, $third:ident}),*) => {
         paste! {
+            #[derive(Debug, Clone, Copy)]
             /// Euler angle (intrinsic)
             pub enum EulerAngleIntrinsic {
                 $(
@@ -44,6 +45,7 @@ macro_rules! make_euler_angle_intrinsic {
 macro_rules! make_euler_angle_extrinsic {
     ($({$first:ident, $second:ident, $third:ident}),*) => {
         paste! {
+            #[derive(Debug, Clone, Copy)]
             /// Euler angle (extrinsic)
             pub enum EulerAngleExtrinsic {
                 $(
@@ -104,7 +106,7 @@ mod tests {
     #[case(PI / 2., 90. * deg)]
     #[case(0., 0. * rad)]
     #[case(PI / 2., PI / 2. * rad)]
-    fn test_to_radians(#[case] expected: f32, #[case] angle: Angle) {
+    fn to_radians(#[case] expected: f32, #[case] angle: Angle) {
         approx::assert_abs_diff_eq!(expected, angle.radian());
     }
 
@@ -115,7 +117,7 @@ mod tests {
     #[case(UnitQuaternion::from_axis_angle(&Vector3::z_axis(), PI / 2.), EulerAngle::XYZ(0. * deg, 0. * deg, 90. * deg))]
     #[case(UnitQuaternion::from_axis_angle(&Vector3::y_axis(), PI / 2.) * UnitQuaternion::from_axis_angle(&Vector3::z_axis(), PI / 2.), EulerAngle::XYZ(0. * deg, 90. * deg, 90. * deg))]
     #[case(UnitQuaternion::from_axis_angle(&Vector3::x_axis(), PI / 2.) * UnitQuaternion::from_axis_angle(&Vector3::y_axis(), PI / 2.), EulerAngle::XYZ(90. * deg, 90. * deg, 0. * deg))]
-    fn test_rotation_xyz(#[case] expected: UnitQuaternion, #[case] angle: EulerAngle) {
+    fn xyz_intrinsic(#[case] expected: UnitQuaternion, #[case] angle: EulerAngle) {
         let angle: UnitQuaternion = angle.into();
         assert_approx_eq_quat!(expected, angle);
     }
@@ -127,7 +129,7 @@ mod tests {
     #[case(UnitQuaternion::from_axis_angle(&Vector3::z_axis(), PI / 2.), EulerAngle::ZYZ(0. * deg, 0. * deg, 90. * deg))]
     #[case(UnitQuaternion::from_axis_angle(&Vector3::y_axis(), PI / 2.) * UnitQuaternion::from_axis_angle(&Vector3::z_axis(), PI / 2.), EulerAngle::ZYZ(0. * deg, 90. * deg, 90. * deg))]
     #[case(UnitQuaternion::from_axis_angle(&Vector3::z_axis(), PI / 2.) * UnitQuaternion::from_axis_angle(&Vector3::y_axis(), PI / 2.), EulerAngle::ZYZ(90. * deg, 90. * deg, 0. * deg))]
-    fn test_rotation_zyz(#[case] expected: UnitQuaternion, #[case] angle: EulerAngle) {
+    fn zyz_intrinsic(#[case] expected: UnitQuaternion, #[case] angle: EulerAngle) {
         let angle: UnitQuaternion = angle.into();
         assert_approx_eq_quat!(expected, angle);
     }
@@ -139,10 +141,7 @@ mod tests {
     #[case(UnitQuaternion::from_axis_angle(&Vector3::z_axis(), PI / 2.), EulerAngleExtrinsic::XYZ(0. * deg, 0. * deg, 90. * deg))]
     #[case(UnitQuaternion::from_axis_angle(&Vector3::z_axis(), PI / 2.) * UnitQuaternion::from_axis_angle(&Vector3::y_axis(), PI / 2.), EulerAngleExtrinsic::XYZ(0. * deg, 90. * deg, 90. * deg))]
     #[case(UnitQuaternion::from_axis_angle(&Vector3::y_axis(), PI / 2.) * UnitQuaternion::from_axis_angle(&Vector3::x_axis(), PI / 2.), EulerAngleExtrinsic::XYZ(90. * deg, 90. * deg, 0. * deg))]
-    fn test_rotation_xyz_extrinsic(
-        #[case] expected: UnitQuaternion,
-        #[case] angle: EulerAngleExtrinsic,
-    ) {
+    fn xyz_extrinsic(#[case] expected: UnitQuaternion, #[case] angle: EulerAngleExtrinsic) {
         let angle: UnitQuaternion = angle.into();
         assert_approx_eq_quat!(expected, angle);
     }
@@ -154,10 +153,7 @@ mod tests {
     #[case(UnitQuaternion::from_axis_angle(&Vector3::z_axis(), PI / 2.), EulerAngleExtrinsic::ZYZ(0. * deg, 0. * deg, 90. * deg))]
     #[case(UnitQuaternion::from_axis_angle(&Vector3::z_axis(), PI / 2.) * UnitQuaternion::from_axis_angle(&Vector3::y_axis(), PI / 2.), EulerAngleExtrinsic::ZYZ(0. * deg, 90. * deg, 90. * deg))]
     #[case(UnitQuaternion::from_axis_angle(&Vector3::y_axis(), PI / 2.) * UnitQuaternion::from_axis_angle(&Vector3::z_axis(), PI / 2.), EulerAngleExtrinsic::ZYZ(90. * deg, 90. * deg, 0. * deg))]
-    fn test_rotation_zyz_extrinsic(
-        #[case] expected: UnitQuaternion,
-        #[case] angle: EulerAngleExtrinsic,
-    ) {
+    fn zyz_extrinsic(#[case] expected: UnitQuaternion, #[case] angle: EulerAngleExtrinsic) {
         let angle: UnitQuaternion = angle.into();
         assert_approx_eq_quat!(expected, angle);
     }

--- a/autd3-core/src/geometry/transducer.rs
+++ b/autd3-core/src/geometry/transducer.rs
@@ -1,6 +1,6 @@
 use getset::Getters;
 
-use super::{Isometry, Point3};
+use super::Point3;
 
 /// A ultrasound transducer.
 #[derive(Clone, Debug, PartialEq, Getters)]
@@ -15,10 +15,10 @@ pub struct Transducer {
 impl Transducer {
     /// Creates a new [`Transducer`].
     #[must_use]
-    pub const fn new(idx: u8, dev_idx: u16, position: Point3) -> Self {
+    pub const fn new(position: Point3) -> Self {
         Self {
-            idx,
-            dev_idx,
+            idx: 0,
+            dev_idx: 0,
             position,
         }
     }
@@ -42,8 +42,8 @@ mod tests {
 
     #[test]
     fn idx() {
-        let tr = Transducer::new(1, 2, Point3::origin());
-        assert_eq!(1, tr.idx());
-        assert_eq!(2, tr.dev_idx());
+        let tr = Transducer::new(Point3::origin());
+        assert_eq!(0, tr.idx());
+        assert_eq!(0, tr.dev_idx());
     }
 }

--- a/autd3-core/src/geometry/transducer.rs
+++ b/autd3-core/src/geometry/transducer.rs
@@ -5,8 +5,8 @@ use super::{Isometry, Point3};
 /// A ultrasound transducer.
 #[derive(Clone, Debug, PartialEq, Getters)]
 pub struct Transducer {
-    idx: u8,
-    dev_idx: u16,
+    pub(crate) idx: u8,
+    pub(crate) dev_idx: u16,
     #[getset(get = "pub")]
     /// The position of the transducer.
     position: Point3,
@@ -34,50 +34,16 @@ impl Transducer {
     pub const fn dev_idx(&self) -> usize {
         self.dev_idx as _
     }
-
-    pub(super) fn affine(&mut self, isometry: &Isometry) {
-        self.position = isometry * self.position;
-    }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::f32::consts::PI;
-
-    use crate::geometry::{Translation, UnitQuaternion, Vector3};
-
     use super::*;
-
-    macro_rules! assert_vec3_approx_eq {
-        ($a:expr, $b:expr) => {
-            approx::assert_abs_diff_eq!($a.x, $b.x, epsilon = 1e-3);
-            approx::assert_abs_diff_eq!($a.y, $b.y, epsilon = 1e-3);
-            approx::assert_abs_diff_eq!($a.z, $b.z, epsilon = 1e-3);
-        };
-    }
 
     #[test]
     fn idx() {
         let tr = Transducer::new(1, 2, Point3::origin());
         assert_eq!(1, tr.idx());
         assert_eq!(2, tr.dev_idx());
-    }
-
-    #[rstest::rstest]
-    #[test]
-    fn affine() {
-        let mut tr = Transducer::new(0, 0, Point3::origin());
-
-        let vector = Vector3::new(40., 50., 60.);
-        let rotation = UnitQuaternion::from_axis_angle(&Vector3::x_axis(), 0.)
-            * UnitQuaternion::from_axis_angle(&Vector3::y_axis(), 0.)
-            * UnitQuaternion::from_axis_angle(&Vector3::z_axis(), PI / 2.);
-        tr.affine(&Isometry {
-            translation: Translation { vector },
-            rotation,
-        });
-
-        let expect_pos = vector;
-        assert_vec3_approx_eq!(expect_pos, tr.position());
     }
 }

--- a/autd3-driver/benches/gain.rs
+++ b/autd3-driver/benches/gain.rs
@@ -8,7 +8,7 @@ use autd3_driver::{
         fpga::{Drive, EmitIntensity, Phase},
         operation::OperationHandler,
     },
-    geometry::{Device, Geometry, IntoDevice, Point3, Transducer},
+    geometry::{Device, Geometry, Point3, Transducer},
 };
 
 use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
@@ -22,7 +22,7 @@ pub fn generate_geometry(size: usize) -> Geometry {
                     pos: Point3::new(i as f32 * AUTD3::DEVICE_WIDTH, 0., 0.),
                     ..Default::default()
                 }
-                .into_device(i as _)
+                .into()
             })
             .collect(),
     )

--- a/autd3-driver/src/datagram/cpu_gpio_out.rs
+++ b/autd3-driver/src/datagram/cpu_gpio_out.rs
@@ -23,13 +23,13 @@ impl CpuGPIOPort {
 
 #[derive(Debug)]
 #[doc(hidden)]
-pub struct CpuGPIO<F: Fn(&Device) -> CpuGPIOPort + Send + Sync> {
+pub struct CpuGPIOOutputs<F: Fn(&Device) -> CpuGPIOPort + Send + Sync> {
     #[debug(ignore)]
     f: F,
 }
 
-impl<F: Fn(&Device) -> CpuGPIOPort + Send + Sync> CpuGPIO<F> {
-    /// Creates a new [`CpuGPIO`].
+impl<F: Fn(&Device) -> CpuGPIOPort + Send + Sync> CpuGPIOOutputs<F> {
+    /// Creates a new [`CpuGPIOOutputs`].
     #[must_use]
     pub const fn new(f: F) -> Self {
         Self { f }
@@ -50,7 +50,7 @@ impl<F: Fn(&Device) -> CpuGPIOPort + Send + Sync> OperationGenerator for CpuGPIO
     }
 }
 
-impl<F: Fn(&Device) -> CpuGPIOPort + Send + Sync> Datagram for CpuGPIO<F> {
+impl<F: Fn(&Device) -> CpuGPIOPort + Send + Sync> Datagram for CpuGPIOOutputs<F> {
     type G = CpuGPIOOutOpGenerator<F>;
     type Error = Infallible;
 

--- a/autd3-driver/src/datagram/debug.rs
+++ b/autd3-driver/src/datagram/debug.rs
@@ -13,9 +13,9 @@ use derive_more::Debug;
 /// # Example
 ///
 /// ```
-/// # use autd3_driver::datagram::DebugSettings;
+/// # use autd3_driver::datagram::GPIOOutputs;
 /// # use autd3_driver::firmware::fpga::{DebugType, GPIOOut};
-/// DebugSettings::new(|dev, gpio| match gpio {
+/// GPIOOutputs::new(|dev, gpio| match gpio {
 ///     GPIOOut::O0 => DebugType::BaseSignal,
 ///     GPIOOut::O1 => DebugType::Sync,
 ///     GPIOOut::O2 => DebugType::PwmOut(&dev[0]),
@@ -23,13 +23,13 @@ use derive_more::Debug;
 /// });
 /// ```
 #[derive(Debug)]
-pub struct DebugSettings<F: Fn(&Device, GPIOOut) -> DebugType + Send + Sync> {
+pub struct GPIOOutputs<F: Fn(&Device, GPIOOut) -> DebugType + Send + Sync> {
     #[debug(ignore)]
     f: F,
 }
 
-impl<F: Fn(&Device, GPIOOut) -> DebugType + Send + Sync> DebugSettings<F> {
-    /// Creates a new [`DebugSettings`].
+impl<F: Fn(&Device, GPIOOut) -> DebugType + Send + Sync> GPIOOutputs<F> {
+    /// Creates a new [`GPIOOutputs`].
     #[must_use]
     pub const fn new(f: F) -> Self {
         Self { f }
@@ -57,7 +57,7 @@ impl<F: Fn(&Device, GPIOOut) -> DebugType + Send + Sync> OperationGenerator
     }
 }
 
-impl<F: Fn(&Device, GPIOOut) -> DebugType + Send + Sync> Datagram for DebugSettings<F> {
+impl<F: Fn(&Device, GPIOOut) -> DebugType + Send + Sync> Datagram for GPIOOutputs<F> {
     type G = DebugSettingOpGenerator<F>;
     type Error = Infallible;
 

--- a/autd3-driver/src/datagram/mod.rs
+++ b/autd3-driver/src/datagram/mod.rs
@@ -30,7 +30,7 @@ pub use clear::Clear;
 pub use clock::ConfigureFPGAClock;
 #[doc(hidden)]
 pub use cpu_gpio_out::{CpuGPIO, CpuGPIOPort};
-pub use debug::DebugSettings;
+pub use debug::GPIOOutputs;
 pub use force_fan::ForceFan;
 pub use gain::{BoxedGain, IntoBoxedGain};
 #[doc(hidden)]

--- a/autd3-driver/src/datagram/mod.rs
+++ b/autd3-driver/src/datagram/mod.rs
@@ -29,7 +29,7 @@ pub use clear::Clear;
 #[cfg(feature = "dynamic_freq")]
 pub use clock::ConfigureFPGAClock;
 #[doc(hidden)]
-pub use cpu_gpio_out::{CpuGPIO, CpuGPIOPort};
+pub use cpu_gpio_out::{CpuGPIOOutputs, CpuGPIOPort};
 pub use debug::GPIOOutputs;
 pub use force_fan::ForceFan;
 pub use gain::{BoxedGain, IntoBoxedGain};

--- a/autd3-driver/src/datagram/mod.rs
+++ b/autd3-driver/src/datagram/mod.rs
@@ -67,10 +67,6 @@ pub(crate) mod tests {
     use super::*;
 
     pub fn create_geometry(n: u16, num_trans_in_unit: u8) -> Geometry {
-        Geometry::new(
-            (0..n)
-                .map(|i| create_device(i, num_trans_in_unit))
-                .collect(),
-        )
+        Geometry::new((0..n).map(|_| create_device(num_trans_in_unit)).collect())
     }
 }

--- a/autd3-driver/src/firmware/fpga/debug_type.rs
+++ b/autd3-driver/src/firmware/fpga/debug_type.rs
@@ -5,9 +5,9 @@ use zerocopy::{Immutable, IntoBytes};
 
 use super::ec_time_to_sys_time;
 
-/// Output of the GPIO pin. See also [`DebugSettings`].
+/// Output of the GPIO pin. See also [`GPIOOutputs`].
 ///
-/// [`DebugSettings`]: crate::datagram::DebugSettings
+/// [`GPIOOutputs`]: crate::datagram::GPIOOutputs
 #[non_exhaustive]
 #[derive(Clone, Debug)]
 pub enum DebugType<'a> {

--- a/autd3-driver/src/firmware/fpga/debug_type.rs
+++ b/autd3-driver/src/firmware/fpga/debug_type.rs
@@ -107,10 +107,10 @@ mod tests {
         assert_eq!("StmIdx(1)", format!("{:?}", DebugType::StmIdx(1)));
         assert_eq!("IsStmMode", format!("{:?}", DebugType::IsStmMode));
         assert_eq!(
-            "PwmOut(1)",
+            "PwmOut(0)",
             format!(
                 "{:?}",
-                DebugType::PwmOut(&Transducer::new(1, 1, Point3::origin()))
+                DebugType::PwmOut(&Transducer::new(Point3::origin()))
             )
         );
         assert_eq!("Direct(true)", format!("{:?}", DebugType::Direct(true)));

--- a/autd3-driver/src/firmware/operation/clear.rs
+++ b/autd3-driver/src/firmware/operation/clear.rs
@@ -60,7 +60,7 @@ mod tests {
 
     #[test]
     fn test() {
-        let device = create_device(0, NUM_TRANS_IN_UNIT);
+        let device = create_device(NUM_TRANS_IN_UNIT);
 
         let mut tx = [0x00u8; size_of::<Clear>()];
 

--- a/autd3-driver/src/firmware/operation/clock/mod.rs
+++ b/autd3-driver/src/firmware/operation/clock/mod.rs
@@ -285,7 +285,7 @@ mod tests {
 
         let mut tx = vec![0x00u8; FRAME_SIZE];
 
-        let device = create_device(0, NUM_TRANS_IN_UNIT);
+        let device = create_device(NUM_TRANS_IN_UNIT);
 
         let mut op = ConfigureClockOp::new(freq);
 
@@ -379,7 +379,7 @@ mod tests {
     #[case::f1(Err(AUTDDriverError::InvalidFrequency(1*Hz)), 1*Hz)]
     #[case::f32(Err(AUTDDriverError::InvalidFrequency(125*Hz)), 125*Hz)]
     fn config_clk_validate(#[case] expect: Result<(), AUTDDriverError>, #[case] freq: Freq<u32>) {
-        let device = create_device(0, NUM_TRANS_IN_UNIT);
+        let device = create_device(NUM_TRANS_IN_UNIT);
         let mut tx = vec![0x00u8; size_of::<Clk>() + DRP_ROM_SIZE * size_of::<u64>()];
 
         let mut op = ConfigureClockOp::new(freq);

--- a/autd3-driver/src/firmware/operation/cpu_gpio_out.rs
+++ b/autd3-driver/src/firmware/operation/cpu_gpio_out.rs
@@ -72,7 +72,7 @@ mod tests {
     fn debug_op(#[case] expect: u8, #[case] pa5: bool, #[case] pa7: bool) {
         const FRAME_SIZE: usize = size_of::<CpuGPIOOut>();
 
-        let device = create_device(0, NUM_TRANS_IN_UNIT);
+        let device = create_device(NUM_TRANS_IN_UNIT);
         let mut tx = vec![0x00u8; FRAME_SIZE];
 
         let mut op = CpuGPIOOutOp::new(pa5, pa7);

--- a/autd3-driver/src/firmware/operation/debug.rs
+++ b/autd3-driver/src/firmware/operation/debug.rs
@@ -70,7 +70,7 @@ mod tests {
     fn debug_op() {
         const FRAME_SIZE: usize = size_of::<DebugSetting>();
 
-        let device = create_device(0, NUM_TRANS_IN_UNIT);
+        let device = create_device(NUM_TRANS_IN_UNIT);
         let mut tx = vec![0x00u8; FRAME_SIZE];
 
         let mut op = DebugSettingOp::new([

--- a/autd3-driver/src/firmware/operation/force_fan.rs
+++ b/autd3-driver/src/firmware/operation/force_fan.rs
@@ -67,7 +67,7 @@ mod tests {
     #[case(0x01, true)]
     #[case(0x00, false)]
     fn test(#[case] expect: u8, #[case] value: bool) {
-        let device = create_device(0, NUM_TRANS_IN_UNIT);
+        let device = create_device(NUM_TRANS_IN_UNIT);
 
         let mut tx = [0x00u8; size_of::<ForceFan>()];
 

--- a/autd3-driver/src/firmware/operation/gain.rs
+++ b/autd3-driver/src/firmware/operation/gain.rs
@@ -121,7 +121,7 @@ mod tests {
 
     #[test]
     fn test() {
-        let device = create_device(0, NUM_TRANS_IN_UNIT as _);
+        let device = create_device(NUM_TRANS_IN_UNIT as _);
 
         let mut tx = vec![0x00u8; size_of::<Gain>() + NUM_TRANS_IN_UNIT * size_of::<Drive>()];
 
@@ -163,7 +163,7 @@ mod tests {
 
     #[test]
     fn invalid_transition_mode() {
-        let device = create_device(0, NUM_TRANS_IN_UNIT as _);
+        let device = create_device(NUM_TRANS_IN_UNIT as _);
 
         let mut tx = vec![0x00u8; size_of::<Gain>() + NUM_TRANS_IN_UNIT * size_of::<Drive>()];
 

--- a/autd3-driver/src/firmware/operation/gpio_in.rs
+++ b/autd3-driver/src/firmware/operation/gpio_in.rs
@@ -84,7 +84,7 @@ mod tests {
     #[case(0b1001, [true, false, false, true])]
     #[case(0b0110, [false, true, true, false])]
     fn test(#[case] expected: u8, #[case] value: [bool; 4]) {
-        let device = create_device(0, NUM_TRANS_IN_UNIT);
+        let device = create_device(NUM_TRANS_IN_UNIT);
 
         let mut tx = [0x00u8; size_of::<EmulateGPIOIn>()];
 

--- a/autd3-driver/src/firmware/operation/info.rs
+++ b/autd3-driver/src/firmware/operation/info.rs
@@ -77,7 +77,7 @@ mod tests {
     #[case(FirmwareVersionType::FPGAFunctions)]
     #[case(FirmwareVersionType::Clear)]
     fn test(#[case] ty: FirmwareVersionType) {
-        let device = create_device(0, NUM_TRANS_IN_UNIT);
+        let device = create_device(NUM_TRANS_IN_UNIT);
 
         let mut tx = [0x00u8; size_of::<FirmInfo>()];
 

--- a/autd3-driver/src/firmware/operation/mod.rs
+++ b/autd3-driver/src/firmware/operation/mod.rs
@@ -212,13 +212,10 @@ pub(crate) mod tests {
 
     use super::*;
 
-    pub fn create_device(idx: u16, n: u8) -> Device {
+    pub fn create_device(n: u8) -> Device {
         Device::new(
-            idx,
             UnitQuaternion::identity(),
-            (0..n)
-                .map(|i| Transducer::new(i, idx, Point3::origin()))
-                .collect(),
+            (0..n).map(|_| Transducer::new(Point3::origin())).collect(),
         )
     }
 
@@ -257,9 +254,8 @@ pub(crate) mod tests {
         use crate::geometry::Point3;
 
         let geometry = Geometry::new(vec![Device::new(
-            0,
             UnitQuaternion::identity(),
-            vec![Transducer::new(0, 0, Point3::origin())],
+            vec![Transducer::new(Point3::origin())],
         )]);
 
         let mut op = vec![Some((
@@ -310,9 +306,8 @@ pub(crate) mod tests {
     #[test]
     fn test_first() {
         let geometry = Geometry::new(vec![Device::new(
-            0,
             UnitQuaternion::identity(),
-            vec![Transducer::new(0, 0, Point3::origin())],
+            vec![Transducer::new(Point3::origin())],
         )]);
 
         let mut op = vec![Some((
@@ -345,9 +340,8 @@ pub(crate) mod tests {
     #[test]
     fn test_second() {
         let geometry = Geometry::new(vec![Device::new(
-            0,
             UnitQuaternion::identity(),
-            vec![Transducer::new(0, 0, Point3::origin())],
+            vec![Transducer::new(Point3::origin())],
         )]);
 
         let mut op = vec![Some((
@@ -380,9 +374,8 @@ pub(crate) mod tests {
     #[test]
     fn test_broken_pack() {
         let geometry = Geometry::new(vec![Device::new(
-            0,
             UnitQuaternion::identity(),
-            vec![Transducer::new(0, 0, Point3::origin())],
+            vec![Transducer::new(Point3::origin())],
         )]);
 
         let mut op = vec![Some((
@@ -437,9 +430,8 @@ pub(crate) mod tests {
     #[test]
     fn test_finished() {
         let geometry = Geometry::new(vec![Device::new(
-            0,
             UnitQuaternion::identity(),
-            vec![Transducer::new(0, 0, Point3::origin())],
+            vec![Transducer::new(Point3::origin())],
         )]);
 
         let mut op = vec![Some((
@@ -467,9 +459,8 @@ pub(crate) mod tests {
     #[test]
     fn msg_id() {
         let geometry = Geometry::new(vec![Device::new(
-            0,
             UnitQuaternion::identity(),
-            vec![Transducer::new(0, 0, Point3::origin())],
+            vec![Transducer::new(Point3::origin())],
         )]);
 
         let mut tx = vec![TxMessage::new_zeroed(); 1];

--- a/autd3-driver/src/firmware/operation/modulation.rs
+++ b/autd3-driver/src/firmware/operation/modulation.rs
@@ -181,7 +181,7 @@ mod tests {
     fn test() {
         const MOD_SIZE: usize = 100;
 
-        let device = create_device(0, NUM_TRANS_IN_UNIT as _);
+        let device = create_device(NUM_TRANS_IN_UNIT as _);
 
         let mut tx = vec![0x00u8; size_of::<ModulationHead>() + MOD_SIZE];
 
@@ -255,7 +255,7 @@ mod tests {
         const MOD_SIZE: usize = FRAME_SIZE - size_of::<ModulationHead>()
             + (FRAME_SIZE - size_of::<ModulationSubseq>()) * 2;
 
-        let device = create_device(0, NUM_TRANS_IN_UNIT as _);
+        let device = create_device(NUM_TRANS_IN_UNIT as _);
 
         let mut tx = vec![0x00u8; FRAME_SIZE];
 
@@ -368,7 +368,7 @@ mod tests {
     fn out_of_range(#[case] expected: Result<(), AUTDDriverError>, #[case] size: usize) {
         let send = |n: usize| {
             const FRAME_SIZE: usize = size_of::<ModulationHead>() + NUM_TRANS_IN_UNIT * 2;
-            let device = create_device(0, NUM_TRANS_IN_UNIT as _);
+            let device = create_device(NUM_TRANS_IN_UNIT as _);
             let mut tx = vec![0x00u8; FRAME_SIZE];
             let buf = Arc::new(vec![0x00; n]);
             let mut op = ModulationOp::new(
@@ -395,7 +395,7 @@ mod tests {
     #[case(253)]
     #[case(255)]
     fn odd_size(#[case] size: usize) -> anyhow::Result<()> {
-        let device = create_device(0, NUM_TRANS_IN_UNIT as _);
+        let device = create_device(NUM_TRANS_IN_UNIT as _);
 
         let mut tx = vec![0x00u8; NUM_TRANS_IN_UNIT * 2];
 

--- a/autd3-driver/src/firmware/operation/phase_corr.rs
+++ b/autd3-driver/src/firmware/operation/phase_corr.rs
@@ -72,7 +72,7 @@ mod tests {
 
     #[test]
     fn test() {
-        let device = create_device(0, NUM_TRANS_IN_UNIT);
+        let device = create_device(NUM_TRANS_IN_UNIT);
 
         let mut tx = [0x00u8; 2 * (size_of::<PhaseCorr>() + 250)];
 

--- a/autd3-driver/src/firmware/operation/pulse_width_encoder.rs
+++ b/autd3-driver/src/firmware/operation/pulse_width_encoder.rs
@@ -74,7 +74,7 @@ mod tests {
 
     #[test]
     fn test() {
-        let device = create_device(0, NUM_TRANS_IN_UNIT);
+        let device = create_device(NUM_TRANS_IN_UNIT);
 
         let mut tx = [0x00u8; 2 * (size_of::<Pwe>() + PWE_BUF_SIZE)];
 

--- a/autd3-driver/src/firmware/operation/reads_fpga_state.rs
+++ b/autd3-driver/src/firmware/operation/reads_fpga_state.rs
@@ -67,7 +67,7 @@ mod tests {
     #[case(0x01, true)]
     #[case(0x00, false)]
     fn test(#[case] expected: u8, #[case] value: bool) {
-        let device = create_device(0, NUM_TRANS_IN_UNIT);
+        let device = create_device(NUM_TRANS_IN_UNIT);
 
         let mut tx = [0x00u8; 2 * size_of::<ReadsFPGAState>()];
 

--- a/autd3-driver/src/firmware/operation/segment.rs
+++ b/autd3-driver/src/firmware/operation/segment.rs
@@ -139,7 +139,7 @@ mod tests {
     fn gain() {
         const FRAME_SIZE: usize = size_of::<SwapSegmentT>();
 
-        let device = create_device(0, NUM_TRANS_IN_UNIT);
+        let device = create_device(NUM_TRANS_IN_UNIT);
         let mut tx = vec![0x00u8; FRAME_SIZE];
 
         let mut op = SwapSegmentOp::new(SwapSegment::Gain(Segment::S0, TransitionMode::Immediate));
@@ -155,7 +155,7 @@ mod tests {
     fn gain_invalid_transition_mode() {
         const FRAME_SIZE: usize = size_of::<SwapSegmentT>();
 
-        let device = create_device(0, NUM_TRANS_IN_UNIT);
+        let device = create_device(NUM_TRANS_IN_UNIT);
         let mut tx = vec![0x00u8; FRAME_SIZE];
 
         let mut op = SwapSegmentOp::new(SwapSegment::Gain(Segment::S0, TransitionMode::Ext));
@@ -170,7 +170,7 @@ mod tests {
     fn modulation() {
         const FRAME_SIZE: usize = size_of::<SwapSegmentTWithTransition>();
 
-        let device = create_device(0, NUM_TRANS_IN_UNIT);
+        let device = create_device(NUM_TRANS_IN_UNIT);
         let mut tx = vec![0x00u8; FRAME_SIZE];
 
         let sys_time = DcSysTime::ZERO + std::time::Duration::from_nanos(0x0123456789ABCDEF);
@@ -198,7 +198,7 @@ mod tests {
     fn foci_stm() {
         const FRAME_SIZE: usize = size_of::<SwapSegmentTWithTransition>();
 
-        let device = create_device(0, NUM_TRANS_IN_UNIT);
+        let device = create_device(NUM_TRANS_IN_UNIT);
         let mut tx = vec![0x00u8; FRAME_SIZE];
 
         let sys_time = DcSysTime::ZERO + std::time::Duration::from_nanos(0x0123456789ABCDEF);
@@ -226,7 +226,7 @@ mod tests {
     fn gain_stm() {
         const FRAME_SIZE: usize = size_of::<SwapSegmentTWithTransition>();
 
-        let device = create_device(0, NUM_TRANS_IN_UNIT);
+        let device = create_device(NUM_TRANS_IN_UNIT);
         let mut tx = vec![0x00u8; FRAME_SIZE];
 
         let sys_time = DcSysTime::ZERO + std::time::Duration::from_nanos(0x0123456789ABCDEF);

--- a/autd3-driver/src/firmware/operation/silencer/completion_steps.rs
+++ b/autd3-driver/src/firmware/operation/silencer/completion_steps.rs
@@ -94,7 +94,7 @@ mod tests {
     #[case(SilencerControlFlags::STRICT_MODE.bits(), true)]
     #[case(0x00, false)]
     fn test(#[case] value: u8, #[case] strict_mode: bool) {
-        let device = create_device(0, NUM_TRANS_IN_UNIT);
+        let device = create_device(NUM_TRANS_IN_UNIT);
 
         let mut tx = [0x00u8; size_of::<SilencerFixedCompletionSteps>()];
 

--- a/autd3-driver/src/firmware/operation/silencer/completion_time.rs
+++ b/autd3-driver/src/firmware/operation/silencer/completion_time.rs
@@ -115,7 +115,7 @@ mod tests {
     #[case(SilencerControlFlags::STRICT_MODE.bits(), true)]
     #[case(0x00, false)]
     fn test(#[case] value: u8, #[case] strict_mode: bool) {
-        let device = create_device(0, NUM_TRANS_IN_UNIT);
+        let device = create_device(NUM_TRANS_IN_UNIT);
 
         let mut tx = [0x00u8; size_of::<SilencerFixedCompletionTime>()];
 
@@ -181,7 +181,7 @@ mod tests {
         #[case] time_intensity: Duration,
         #[case] time_phase: Duration,
     ) {
-        let device = create_device(0, NUM_TRANS_IN_UNIT);
+        let device = create_device(NUM_TRANS_IN_UNIT);
 
         let mut tx = [0x00u8; size_of::<SilencerFixedCompletionTime>()];
 

--- a/autd3-driver/src/firmware/operation/silencer/update_rate.rs
+++ b/autd3-driver/src/firmware/operation/silencer/update_rate.rs
@@ -85,7 +85,7 @@ mod tests {
 
     #[test]
     fn test() {
-        let device = create_device(0, NUM_TRANS_IN_UNIT);
+        let device = create_device(NUM_TRANS_IN_UNIT);
 
         let mut tx = [0x00u8; size_of::<SilencerFixedUpdateRate>()];
 

--- a/autd3-driver/src/firmware/operation/stm/foci.rs
+++ b/autd3-driver/src/firmware/operation/stm/foci.rs
@@ -239,7 +239,7 @@ mod tests {
         const FOCI_STM_SIZE: usize = 100;
         const FRAME_SIZE: usize = size_of::<FociSTMHead>() + size_of::<STMFocus>() * FOCI_STM_SIZE;
 
-        let device = create_device(0, NUM_TRANS_IN_UNIT);
+        let device = create_device(NUM_TRANS_IN_UNIT);
 
         let mut tx = vec![0x00u8; FRAME_SIZE];
 
@@ -339,7 +339,7 @@ mod tests {
         const FRAME_SIZE: usize =
             size_of::<FociSTMHead>() + size_of::<STMFocus>() * FOCI_STM_SIZE * N;
 
-        let device = create_device(0, NUM_TRANS_IN_UNIT);
+        let device = create_device(NUM_TRANS_IN_UNIT);
 
         let mut tx = vec![0x00u8; FRAME_SIZE];
 
@@ -450,7 +450,7 @@ mod tests {
         const FRAME_SIZE: usize = 32;
         const FOCI_STM_SIZE: usize = 7;
 
-        let device = create_device(0, NUM_TRANS_IN_UNIT);
+        let device = create_device(NUM_TRANS_IN_UNIT);
 
         let mut tx = vec![0x00u8; FRAME_SIZE];
 
@@ -624,7 +624,7 @@ mod tests {
         const FOCI_STM_SIZE: usize = 100;
         const FRAME_SIZE: usize = 16 + 8 * FOCI_STM_SIZE;
 
-        let device = create_device(0, NUM_TRANS_IN_UNIT);
+        let device = create_device(NUM_TRANS_IN_UNIT);
 
         let mut tx = vec![0x00u8; FRAME_SIZE];
 
@@ -657,7 +657,7 @@ mod tests {
     #[case(Ok(()), FOCI_STM_BUF_SIZE_MAX)]
     #[case(Err(AUTDDriverError::FociSTMPointSizeOutOfRange(FOCI_STM_BUF_SIZE_MAX+1)), FOCI_STM_BUF_SIZE_MAX+1)]
     fn test_buffer_out_of_range(#[case] expected: Result<(), AUTDDriverError>, #[case] n: usize) {
-        let device = create_device(0, NUM_TRANS_IN_UNIT);
+        let device = create_device(NUM_TRANS_IN_UNIT);
 
         let mut op = FociSTMOp::new(
             TestIterator {
@@ -679,7 +679,7 @@ mod tests {
 
     #[test]
     fn test_foci_out_of_range() {
-        let device = create_device(0, NUM_TRANS_IN_UNIT);
+        let device = create_device(NUM_TRANS_IN_UNIT);
 
         {
             let mut op = FociSTMOp::new(

--- a/autd3-driver/src/firmware/operation/stm/gain.rs
+++ b/autd3-driver/src/firmware/operation/stm/gain.rs
@@ -293,7 +293,7 @@ mod tests {
         const GAIN_STM_SIZE: usize = 3;
         const FRAME_SIZE: usize = size_of::<GainSTMHead>() + NUM_TRANS_IN_UNIT * 2;
 
-        let device = create_device(0, NUM_TRANS_IN_UNIT as _);
+        let device = create_device(NUM_TRANS_IN_UNIT as _);
 
         let mut tx = vec![0x00u8; FRAME_SIZE];
 
@@ -443,7 +443,7 @@ mod tests {
         const GAIN_STM_SIZE: usize = 5;
         const FRAME_SIZE: usize = size_of::<GainSTMHead>() + NUM_TRANS_IN_UNIT * 2;
 
-        let device = create_device(0, NUM_TRANS_IN_UNIT as _);
+        let device = create_device(NUM_TRANS_IN_UNIT as _);
 
         let mut tx = vec![0x00u8; FRAME_SIZE];
 
@@ -575,7 +575,7 @@ mod tests {
     fn test_phase_half() {
         const GAIN_STM_SIZE: usize = 9;
 
-        let device = create_device(0, NUM_TRANS_IN_UNIT as _);
+        let device = create_device(NUM_TRANS_IN_UNIT as _);
 
         let mut tx = vec![TxMessage::new_zeroed(); 1];
         let tx = tx[0].payload_mut();
@@ -725,7 +725,7 @@ mod tests {
     fn out_of_range(#[case] expected: Result<(), AUTDDriverError>, #[case] size: usize) {
         let send = |n: usize| {
             const FRAME_SIZE: usize = size_of::<GainSTMHead>() + NUM_TRANS_IN_UNIT * 2;
-            let device = create_device(0, NUM_TRANS_IN_UNIT as _);
+            let device = create_device(NUM_TRANS_IN_UNIT as _);
             let mut tx = vec![0x00u8; FRAME_SIZE];
             let data = (0..n)
                 .map(|_| vec![Drive::NULL; NUM_TRANS_IN_UNIT])

--- a/autd3-driver/src/firmware/operation/sync.rs
+++ b/autd3-driver/src/firmware/operation/sync.rs
@@ -70,7 +70,7 @@ mod tests {
 
     #[test]
     fn test() {
-        let device = create_device(0, NUM_TRANS_IN_UNIT);
+        let device = create_device(NUM_TRANS_IN_UNIT);
 
         let mut tx = [0x00u8; size_of::<Sync>()];
 

--- a/autd3-firmware-emulator/tests/op/cpu_gpio_out.rs
+++ b/autd3-firmware-emulator/tests/op/cpu_gpio_out.rs
@@ -20,7 +20,7 @@ fn send_cpu_gpio_out(
     let mut cpu = CPUEmulator::new(0, geometry.num_transducers());
     let mut tx = vec![TxMessage::new_zeroed(); 1];
 
-    let d = CpuGPIO::new(|_| CpuGPIOPort::new(pa5, pa7));
+    let d = CpuGPIOOutputs::new(|_| CpuGPIOPort::new(pa5, pa7));
 
     assert_eq!(Ok(()), send(&mut cpu, d, &geometry, &mut tx));
 

--- a/autd3-firmware-emulator/tests/op/debug.rs
+++ b/autd3-firmware-emulator/tests/op/debug.rs
@@ -26,7 +26,7 @@ fn send_debug_output_idx(
     let mut cpu = CPUEmulator::new(0, geometry.num_transducers());
     let mut tx = vec![TxMessage::new_zeroed(); 1];
 
-    let d = DebugSettings::new(|_, gpio| match gpio {
+    let d = GPIOOutputs::new(|_, gpio| match gpio {
         GPIOOut::O0 => debug_types[0].clone(),
         GPIOOut::O1 => debug_types[1].clone(),
         GPIOOut::O2 => debug_types[2].clone(),
@@ -47,7 +47,7 @@ fn send_debug_pwm_out() -> anyhow::Result<()> {
     let mut cpu = CPUEmulator::new(0, geometry.num_transducers());
     let mut tx = vec![TxMessage::new_zeroed(); 1];
 
-    let d = DebugSettings::new(|dev, gpio| match gpio {
+    let d = GPIOOutputs::new(|dev, gpio| match gpio {
         GPIOOut::O0 => DebugType::PwmOut(&dev[0]),
         GPIOOut::O1 => DebugType::PwmOut(&dev[1]),
         GPIOOut::O2 => DebugType::PwmOut(&dev[2]),

--- a/autd3-firmware-emulator/tests/test.rs
+++ b/autd3-firmware-emulator/tests/test.rs
@@ -7,7 +7,7 @@ use autd3_driver::{
         cpu::TxMessage,
         operation::{OperationGenerator, OperationHandler},
     },
-    geometry::{Geometry, IntoDevice, Point3},
+    geometry::{Geometry, Point3},
 };
 use autd3_firmware_emulator::{CPUEmulator, cpu::params::ERR_BIT};
 use zerocopy::FromZeros;
@@ -17,12 +17,12 @@ mod op;
 pub fn create_geometry(n: usize) -> Geometry {
     Geometry::new(
         (0..n)
-            .map(|i| {
+            .map(|_| {
                 AUTD3 {
                     pos: Point3::origin(),
                     ..Default::default()
                 }
-                .into_device(i as _)
+                .into()
             })
             .collect(),
     )

--- a/autd3-gain-holo/src/lib.rs
+++ b/autd3-gain-holo/src/lib.rs
@@ -30,7 +30,7 @@ pub use autd3_core::acoustics::directivity::{Sphere, T4010A1};
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use autd3_core::geometry::{Geometry, IntoDevice, Point3};
+    use autd3_core::geometry::{Geometry, Point3};
     use autd3_driver::autd3_device::AUTD3;
 
     pub fn create_geometry(row: usize, col: usize) -> Geometry {
@@ -42,7 +42,7 @@ pub(crate) mod tests {
                             pos: Point3::new(i as f32 * 192., j as f32 * 151.4, 0.),
                             ..Default::default()
                         }
-                        .into_device((j + i * row) as _)
+                        .into()
                     })
                 })
                 .collect(),

--- a/autd3-protobuf/src/lightweight/client.rs
+++ b/autd3-protobuf/src/lightweight/client.rs
@@ -1,6 +1,6 @@
 use std::net::SocketAddr;
 
-use autd3_core::geometry::{Device, Geometry, IntoDevice};
+use autd3_core::geometry::{Device, Geometry};
 
 use derive_more::Deref;
 
@@ -14,19 +14,11 @@ pub struct LightweightClient {
 }
 
 impl LightweightClient {
-    pub async fn open<D: IntoDevice, F: IntoIterator<Item = D>>(
+    pub async fn open<D: Into<Device>, F: IntoIterator<Item = D>>(
         devices: F,
         addr: SocketAddr,
     ) -> Result<Self, crate::error::AUTDProtoBufError> {
-        LightweightClient::open_impl(
-            devices
-                .into_iter()
-                .enumerate()
-                .map(|(i, d)| d.into_device(i as _))
-                .collect(),
-            addr,
-        )
-        .await
+        LightweightClient::open_impl(devices.into_iter().map(|d| d.into()).collect(), addr).await
     }
 
     async fn open_impl(

--- a/autd3-protobuf/src/traits/driver/geometry/mod.rs
+++ b/autd3-protobuf/src/traits/driver/geometry/mod.rs
@@ -1,5 +1,3 @@
-use autd3_core::geometry::IntoDevice;
-
 use crate::{
     AUTDProtoBufError,
     pb::*,
@@ -103,8 +101,7 @@ impl FromMessage<Geometry> for autd3_core::geometry::Geometry {
         Ok(autd3_core::geometry::Geometry::new(
             msg.devices
                 .into_iter()
-                .enumerate()
-                .map(|(i, dev_msg)| {
+                .map(|dev_msg| {
                     let pos = dev_msg
                         .pos
                         .map(autd3_core::geometry::Point3::from_msg)
@@ -115,8 +112,8 @@ impl FromMessage<Geometry> for autd3_core::geometry::Geometry {
                         .map(autd3_core::geometry::UnitQuaternion::from_msg)
                         .transpose()?
                         .unwrap_or(autd3_core::geometry::UnitQuaternion::identity());
-                    let mut dev =
-                        autd3_driver::autd3_device::AUTD3 { pos, rot }.into_device(i as _);
+                    let mut dev: autd3_core::geometry::Device =
+                        autd3_driver::autd3_device::AUTD3 { pos, rot }.into();
                     if let Some(sound_speed) = dev_msg.sound_speed {
                         dev.sound_speed = sound_speed;
                     }
@@ -178,11 +175,11 @@ mod tests {
     #[test]
     fn geometry() {
         let mut rng = rand::rng();
-        let mut dev = AUTD3 {
+        let mut dev: autd3_core::geometry::Device = AUTD3 {
             pos: Point3::new(rng.random(), rng.random(), rng.random()),
             rot: UnitQuaternion::identity(),
         }
-        .into_device(0);
+        .into();
         dev.sound_speed = rng.random();
         let geometry = Geometry::new(vec![dev]);
         let msg = geometry.to_msg(None).unwrap();

--- a/autd3/src/datagram/modulation/sine.rs
+++ b/autd3/src/datagram/modulation/sine.rs
@@ -11,7 +11,6 @@ use derive_more::Debug;
 
 /// The option of [`Sine`].
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[repr(C)]
 pub struct SineOption {
     /// The intensity of the modulation. The default value is [`u8::MAX`].
     pub intensity: u8,

--- a/autd3/src/datagram/modulation/square.rs
+++ b/autd3/src/datagram/modulation/square.rs
@@ -6,7 +6,6 @@ use derive_more::Debug;
 
 /// The option of [`Square`].
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[repr(C)]
 pub struct SquareOption {
     /// The low value of the modulation. The default value is [`u8::MIN`].
     pub low: u8,

--- a/autd3/src/datagram/stm/circle.rs
+++ b/autd3/src/datagram/stm/circle.rs
@@ -165,7 +165,6 @@ mod tests {
     use autd3_driver::{
         datagram::{FociSTM, GainSTM},
         defined::mm,
-        geometry::IntoDevice,
     };
 
     use crate::assert_near_vector3;
@@ -217,7 +216,7 @@ mod tests {
         assert_eq!(4, FociSTMGenerator::len(&circle));
         assert_eq!(4, GainSTMGenerator::len(&circle));
 
-        let device = autd3_driver::autd3_device::AUTD3::default().into_device(0);
+        let device = autd3_driver::autd3_device::AUTD3::default().into();
         {
             let mut stm = FociSTM {
                 foci: circle.clone(),

--- a/autd3/src/datagram/stm/line.rs
+++ b/autd3/src/datagram/stm/line.rs
@@ -157,8 +157,6 @@ mod tests {
 
     #[test]
     fn line() {
-        use autd3_driver::geometry::IntoDevice;
-
         let length = 30.0 * mm;
         let line = Line {
             start: Point3::new(0., -length / 2., 0.),
@@ -175,7 +173,7 @@ mod tests {
             Point3::new(0., length / 2., 0.),
         ];
 
-        let device = autd3_driver::autd3_device::AUTD3::default().into_device(0);
+        let device = autd3_driver::autd3_device::AUTD3::default().into();
         {
             let mut stm = FociSTM {
                 foci: line.clone(),

--- a/autd3/src/lib.rs
+++ b/autd3/src/lib.rs
@@ -44,7 +44,7 @@ mod tests {
     use autd3_core::geometry::UnitQuaternion;
     use autd3_driver::{
         autd3_device::AUTD3,
-        geometry::{Geometry, IntoDevice, Point3, Vector3},
+        geometry::{Geometry, Point3, Vector3},
     };
 
     #[macro_export]
@@ -99,9 +99,7 @@ mod tests {
     pub fn create_geometry(n: usize) -> Geometry {
         Geometry::new(
             (0..n)
-                .map(|i| {
-                    AUTD3::new(Point3::origin(), UnitQuaternion::identity()).into_device(i as _)
-                })
+                .map(|_| AUTD3::new(Point3::origin(), UnitQuaternion::identity()).into())
                 .collect(),
         )
     }

--- a/autd3/src/prelude.rs
+++ b/autd3/src/prelude.rs
@@ -20,7 +20,7 @@ pub use autd3_core::modulation::Modulation;
 pub use autd3_driver::{
     autd3_device::AUTD3,
     datagram::{
-        Clear, ControlPoint, ControlPoints, DebugSettings, FixedUpdateRate, FociSTM, ForceFan,
+        Clear, ControlPoint, ControlPoints, FixedUpdateRate, FociSTM, ForceFan, GPIOOutputs,
         GainSTM, GainSTMOption, PhaseCorrection, PulseWidthEncoder, ReadsFPGAState, Silencer,
         SwapSegment, WithLoopBehavior, WithSegment,
     },


### PR DESCRIPTION
- **add `ZERO` and `PI` to `Angle`**
- **add `identity` to `EulerAngle`**
- **impl `Debug, Clone, Copy` for `EulerAngle`**
- **update  `AUTD3` to support generic rotation type**
- **rm `#[repr(C)]` from non-FFI safe type**
- **remove ambigous device transformation methods, add `Geometry::reconfigure` instead**
- **update `Device` and `Transducer` constructor**
- **rename from `DebugSettings` to `GPIOOutputs`**
- **rename from `CpuGPIO` to `CpuGPIOOutputs`**
- **bump to v31.0.0**
