### PR TITLE
perf: Transfer management of tx buffer from `Controller` to `Link`

### DIFF
--- a/autd3-core/src/link/async.rs
+++ b/autd3-core/src/link/async.rs
@@ -25,7 +25,7 @@ mod internal {
         }
 
         /// Allocate a sending buffer for the link.
-        async fn alloc_tx_buffer(&mut self) -> Vec<TxMessage>;
+        async fn alloc_tx_buffer(&mut self) -> Result<Vec<TxMessage>, LinkError>;
 
         /// Sends a message to the device.
         async fn send(&mut self, tx: Vec<TxMessage>) -> Result<(), LinkError>;
@@ -52,7 +52,7 @@ mod internal {
             self.as_mut().update(geometry).await
         }
 
-        async fn alloc_tx_buffer(&mut self) -> Vec<TxMessage> {
+        async fn alloc_tx_buffer(&mut self) -> Result<Vec<TxMessage>, LinkError> {
             self.as_mut().alloc_tx_buffer().await
         }
 
@@ -94,7 +94,9 @@ mod internal {
         }
 
         /// Allocate a sending buffer for the link.
-        fn alloc_tx_buffer(&mut self) -> impl std::future::Future<Output = Vec<TxMessage>>;
+        fn alloc_tx_buffer(
+            &mut self,
+        ) -> impl std::future::Future<Output = Result<Vec<TxMessage>, LinkError>>;
 
         /// Sends a message to the device.
         fn send(

--- a/autd3-core/src/link/async.rs
+++ b/autd3-core/src/link/async.rs
@@ -24,8 +24,11 @@ mod internal {
             Ok(())
         }
 
+        /// Allocate a sending buffer for the link.
+        async fn alloc_tx_buffer(&mut self) -> Vec<TxMessage>;
+
         /// Sends a message to the device.
-        async fn send(&mut self, tx: &[TxMessage]) -> Result<(), LinkError>;
+        async fn send(&mut self, tx: Vec<TxMessage>) -> Result<(), LinkError>;
 
         /// Receives a message from the device.
         async fn receive(&mut self, rx: &mut [RxMessage]) -> Result<(), LinkError>;
@@ -49,7 +52,11 @@ mod internal {
             self.as_mut().update(geometry).await
         }
 
-        async fn send(&mut self, tx: &[TxMessage]) -> Result<(), LinkError> {
+        async fn alloc_tx_buffer(&mut self) -> Vec<TxMessage> {
+            self.as_mut().alloc_tx_buffer().await
+        }
+
+        async fn send(&mut self, tx: Vec<TxMessage>) -> Result<(), LinkError> {
             self.as_mut().send(tx).await
         }
 
@@ -86,10 +93,13 @@ mod internal {
             async { Ok(()) }
         }
 
+        /// Allocate a sending buffer for the link.
+        fn alloc_tx_buffer(&mut self) -> impl std::future::Future<Output = Vec<TxMessage>>;
+
         /// Sends a message to the device.
         fn send(
             &mut self,
-            tx: &[TxMessage],
+            tx: Vec<TxMessage>,
         ) -> impl std::future::Future<Output = Result<(), LinkError>>;
 
         /// Receives a message from the device.

--- a/autd3-core/src/link/buffer_pool.rs
+++ b/autd3-core/src/link/buffer_pool.rs
@@ -1,0 +1,45 @@
+use zerocopy::FromZeros;
+
+use crate::derive::Geometry;
+
+use super::TxMessage;
+
+/// A tx buffer pool for single-threaded use
+pub struct TxBufferPoolSync {
+    num_devices: usize,
+    buffer: Option<Vec<TxMessage>>,
+}
+
+impl TxBufferPoolSync {
+    /// Creates a new [`TxBufferPoolSync`].
+    pub const fn new() -> Self {
+        Self {
+            num_devices: 0,
+            buffer: None,
+        }
+    }
+
+    /// Sets the number of devices.
+    pub fn init(&mut self, geometry: &Geometry) {
+        self.num_devices = geometry.len(); // Do not use `num_devices` here because the devices may be disabled.
+    }
+
+    /// Borrows a buffer from the pool.
+    pub fn borrow(&mut self) -> Vec<TxMessage> {
+        self.buffer
+            .take()
+            .unwrap_or_else(|| vec![TxMessage::new_zeroed(); self.num_devices])
+    }
+
+    /// Returns a buffer to the pool.
+    pub fn return_buffer(&mut self, buffer: Vec<TxMessage>) {
+        assert_eq!(buffer.len(), self.num_devices);
+        self.buffer = Some(buffer);
+    }
+}
+
+impl Default for TxBufferPoolSync {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/autd3-core/src/link/buffer_pool.rs
+++ b/autd3-core/src/link/buffer_pool.rs
@@ -1,6 +1,6 @@
 use zerocopy::FromZeros;
 
-use crate::derive::Geometry;
+use crate::geometry::Geometry;
 
 use super::TxMessage;
 

--- a/autd3-core/src/link/datagram/header.rs
+++ b/autd3-core/src/link/datagram/header.rs
@@ -1,11 +1,13 @@
 use derive_more::Debug;
 use zerocopy::{FromZeros, Immutable, IntoBytes};
 
+use super::msg_id::MsgId;
+
 #[doc(hidden)]
 #[repr(C, align(2))]
 #[derive(Clone, Debug, PartialEq, Eq, IntoBytes, Immutable, FromZeros)]
 pub struct Header {
-    pub msg_id: u8,
+    pub msg_id: MsgId,
     #[debug(ignore)]
     __: u8,
     pub slot_2_offset: u16,

--- a/autd3-core/src/link/datagram/mod.rs
+++ b/autd3-core/src/link/datagram/mod.rs
@@ -1,7 +1,9 @@
 mod header;
+mod msg_id;
 mod rx;
 mod tx;
 
 pub use header::Header;
+pub use msg_id::MsgId;
 pub use rx::RxMessage;
 pub use tx::TxMessage;

--- a/autd3-core/src/link/datagram/msg_id.rs
+++ b/autd3-core/src/link/datagram/msg_id.rs
@@ -1,0 +1,25 @@
+use zerocopy::{FromZeros, Immutable, IntoBytes};
+
+#[doc(hidden)]
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, IntoBytes, Immutable, FromZeros)]
+pub struct MsgId(u8);
+
+impl MsgId {
+    pub const MAX: Self = MsgId(0x7F);
+
+    pub const fn new(id: u8) -> Self {
+        MsgId(id)
+    }
+
+    pub const fn get(&self) -> u8 {
+        self.0
+    }
+
+    pub const fn increment(&mut self) {
+        self.0 += 1;
+        if self.0 > Self::MAX.0 {
+            self.0 = 0;
+        }
+    }
+}

--- a/autd3-core/src/link/mod.rs
+++ b/autd3-core/src/link/mod.rs
@@ -1,6 +1,7 @@
 #[cfg_attr(docsrs, doc(cfg(feature = "async")))]
 #[cfg(feature = "async")]
 mod r#async;
+mod buffer_pool;
 mod datagram;
 mod error;
 mod sync;
@@ -8,6 +9,7 @@ mod sync;
 #[cfg(feature = "async")]
 #[doc(inline)]
 pub use r#async::*;
+pub use buffer_pool::*;
 pub use datagram::*;
 pub use error::LinkError;
 #[doc(inline)]

--- a/autd3-core/src/link/sync.rs
+++ b/autd3-core/src/link/sync.rs
@@ -16,7 +16,7 @@ pub trait Link: Send {
     }
 
     /// Allocate a sending buffer for the link.
-    fn alloc_tx_buffer(&mut self) -> Vec<TxMessage>;
+    fn alloc_tx_buffer(&mut self) -> Result<Vec<TxMessage>, LinkError>;
 
     /// Sends a message to the device.
     fn send(&mut self, tx: Vec<TxMessage>) -> Result<(), LinkError>;
@@ -42,7 +42,7 @@ impl Link for Box<dyn Link> {
         self.as_mut().update(geometry)
     }
 
-    fn alloc_tx_buffer(&mut self) -> Vec<TxMessage> {
+    fn alloc_tx_buffer(&mut self) -> Result<Vec<TxMessage>, LinkError> {
         self.as_mut().alloc_tx_buffer()
     }
 

--- a/autd3-core/src/link/sync.rs
+++ b/autd3-core/src/link/sync.rs
@@ -15,8 +15,11 @@ pub trait Link: Send {
         Ok(())
     }
 
+    /// Allocate a sending buffer for the link.
+    fn alloc_tx_buffer(&mut self) -> Vec<TxMessage>;
+
     /// Sends a message to the device.
-    fn send(&mut self, tx: &[TxMessage]) -> Result<(), LinkError>;
+    fn send(&mut self, tx: Vec<TxMessage>) -> Result<(), LinkError>;
 
     /// Receives a message from the device.
     fn receive(&mut self, rx: &mut [RxMessage]) -> Result<(), LinkError>;
@@ -39,7 +42,11 @@ impl Link for Box<dyn Link> {
         self.as_mut().update(geometry)
     }
 
-    fn send(&mut self, tx: &[TxMessage]) -> Result<(), LinkError> {
+    fn alloc_tx_buffer(&mut self) -> Vec<TxMessage> {
+        self.as_mut().alloc_tx_buffer()
+    }
+
+    fn send(&mut self, tx: Vec<TxMessage>) -> Result<(), LinkError> {
         self.as_mut().send(tx)
     }
 

--- a/autd3-driver/benches/gain.rs
+++ b/autd3-driver/benches/gain.rs
@@ -1,4 +1,4 @@
-use autd3_core::derive::*;
+use autd3_core::{derive::*, link::MsgId};
 use autd3_driver::{
     autd3_device::AUTD3,
     datagram::{Datagram, IntoBoxedGain},
@@ -104,7 +104,14 @@ fn focus(c: &mut Criterion) {
                         Focus::new(Point3::new(black_box(90.), black_box(70.), black_box(150.)));
                     let generator = g.operation_generator(geometry, false).unwrap();
                     let mut operations = OperationHandler::generate(generator, geometry);
-                    OperationHandler::pack(&mut operations, geometry, &mut tx, false).unwrap();
+                    OperationHandler::pack(
+                        MsgId::new(0),
+                        &mut operations,
+                        geometry,
+                        &mut tx,
+                        false,
+                    )
+                    .unwrap();
                 })
             },
         );
@@ -126,7 +133,8 @@ fn focus_parallel(c: &mut Criterion) {
                         Focus::new(Point3::new(black_box(90.), black_box(70.), black_box(150.)));
                     let generator = g.operation_generator(geometry, true).unwrap();
                     let mut operations = OperationHandler::generate(generator, geometry);
-                    OperationHandler::pack(&mut operations, geometry, &mut tx, true).unwrap();
+                    OperationHandler::pack(MsgId::new(0), &mut operations, geometry, &mut tx, true)
+                        .unwrap();
                 })
             },
         );
@@ -152,7 +160,14 @@ fn focus_boxed(c: &mut Criterion) {
                     .into_boxed();
                     let generator = g.operation_generator(geometry, false).unwrap();
                     let mut operations = OperationHandler::generate(generator, geometry);
-                    OperationHandler::pack(&mut operations, geometry, &mut tx, false).unwrap();
+                    OperationHandler::pack(
+                        MsgId::new(0),
+                        &mut operations,
+                        geometry,
+                        &mut tx,
+                        false,
+                    )
+                    .unwrap();
                 })
             },
         );

--- a/autd3-driver/benches/gain.rs
+++ b/autd3-driver/benches/gain.rs
@@ -98,6 +98,7 @@ fn focus(c: &mut Criterion) {
             BenchmarkId::new("Gain::Focus", size),
             &generate_geometry(size),
             |b, geometry| {
+                let mut sent_flags = vec![false; size];
                 let mut tx = vec![TxMessage::new_zeroed(); size];
                 b.iter(|| {
                     let g =
@@ -108,6 +109,7 @@ fn focus(c: &mut Criterion) {
                         MsgId::new(0),
                         &mut operations,
                         geometry,
+                        &mut sent_flags,
                         &mut tx,
                         false,
                     )
@@ -127,14 +129,22 @@ fn focus_parallel(c: &mut Criterion) {
             BenchmarkId::new("Gain::FocusParallel", size),
             &generate_geometry(size),
             |b, geometry| {
+                let mut sent_flags = vec![false; size];
                 let mut tx = vec![TxMessage::new_zeroed(); size];
                 b.iter(|| {
                     let g =
                         Focus::new(Point3::new(black_box(90.), black_box(70.), black_box(150.)));
                     let generator = g.operation_generator(geometry, true).unwrap();
                     let mut operations = OperationHandler::generate(generator, geometry);
-                    OperationHandler::pack(MsgId::new(0), &mut operations, geometry, &mut tx, true)
-                        .unwrap();
+                    OperationHandler::pack(
+                        MsgId::new(0),
+                        &mut operations,
+                        geometry,
+                        &mut sent_flags,
+                        &mut tx,
+                        true,
+                    )
+                    .unwrap();
                 })
             },
         );
@@ -150,6 +160,7 @@ fn focus_boxed(c: &mut Criterion) {
             BenchmarkId::new("Gain::FocusBoxed", size),
             &generate_geometry(size),
             |b, geometry| {
+                let mut sent_flags = vec![false; size];
                 let mut tx = vec![TxMessage::new_zeroed(); size];
                 b.iter(|| {
                     let g = Box::new(Focus::new(Point3::new(
@@ -164,6 +175,7 @@ fn focus_boxed(c: &mut Criterion) {
                         MsgId::new(0),
                         &mut operations,
                         geometry,
+                        &mut sent_flags,
                         &mut tx,
                         false,
                     )

--- a/autd3-driver/src/firmware/cpu/mod.rs
+++ b/autd3-driver/src/firmware/cpu/mod.rs
@@ -5,8 +5,6 @@ pub use gain_stm_mode::*;
 
 use crate::error::AUTDDriverError;
 
-pub(crate) const MSG_ID_MAX: u8 = 0x7F;
-
 #[doc(hidden)]
 pub fn check_firmware_err(msg: &RxMessage) -> Result<(), AUTDDriverError> {
     if msg.ack() & 0x80 != 0 {
@@ -22,11 +20,12 @@ pub fn check_if_msg_is_processed<'a>(
 ) -> impl Iterator<Item = bool> + 'a {
     tx.iter()
         .zip(rx.iter())
-        .map(|(tx, r)| tx.header.msg_id == r.ack())
+        .map(|(tx, r)| tx.header.msg_id.get() == r.ack())
 }
 
 #[cfg(test)]
 mod tests {
+    use autd3_core::link::MsgId;
     use itertools::Itertools;
     use zerocopy::FromZeros;
 
@@ -35,9 +34,9 @@ mod tests {
     #[rstest::fixture]
     fn tx() -> Vec<TxMessage> {
         let mut tx = vec![TxMessage::new_zeroed(); 3];
-        tx[0].header.msg_id = 0;
-        tx[1].header.msg_id = 1;
-        tx[2].header.msg_id = 2;
+        tx[0].header.msg_id = MsgId::new(0);
+        tx[1].header.msg_id = MsgId::new(1);
+        tx[2].header.msg_id = MsgId::new(2);
         tx
     }
 

--- a/autd3-driver/src/lib.rs
+++ b/autd3-driver/src/lib.rs
@@ -16,4 +16,4 @@ pub mod error;
 /// A module for working with firmware.
 pub mod firmware;
 
-pub use autd3_core::{defined, ethercat, geometry};
+pub use autd3_core::{defined, ethercat, geometry, link};

--- a/autd3-firmware-emulator/src/cpu/emulator.rs
+++ b/autd3-firmware-emulator/src/cpu/emulator.rs
@@ -1,6 +1,7 @@
 use autd3_driver::{
     ethercat::{DcSysTime, EC_OUTPUT_FRAME_SIZE},
     firmware::cpu::{Header, RxMessage, TxMessage},
+    link::MsgId,
 };
 
 use getset::{CopyGetters, Getters, MutGetters};
@@ -14,7 +15,7 @@ pub struct CPUEmulator {
     #[getset(get_copy = "pub")]
     pub(crate) idx: usize,
     pub(crate) ack: u8,
-    pub(crate) last_msg_id: u8,
+    pub(crate) last_msg_id: MsgId,
     pub(crate) rx_data: u8,
     #[getset(get_copy = "pub")]
     pub(crate) reads_fpga_state: bool,
@@ -60,7 +61,7 @@ impl CPUEmulator {
         let mut s = Self {
             idx: id,
             ack: 0x00,
-            last_msg_id: 0xFF,
+            last_msg_id: MsgId::new(0xFF),
             rx_data: 0x00,
             reads_fpga_state: false,
             reads_fpga_state_store: false,
@@ -138,9 +139,9 @@ impl CPUEmulator {
         self.reads_fpga_state
     }
 
-    pub fn set_last_msg_id(&mut self, msg_id: u8) {
+    pub fn set_last_msg_id(&mut self, msg_id: MsgId) {
         self.last_msg_id = msg_id;
-        self.ack = msg_id;
+        self.ack = msg_id.get();
     }
 }
 
@@ -243,7 +244,7 @@ impl CPUEmulator {
 
         self.read_fpga_state();
 
-        if (header.msg_id & 0x80) != 0 {
+        if (header.msg_id.get() & 0x80) != 0 {
             self.ack = ERR_INVALID_MSG_ID;
             return;
         }
@@ -268,7 +269,7 @@ impl CPUEmulator {
             self.fpga_flags_internal,
         );
 
-        self.ack = header.msg_id;
+        self.ack = header.msg_id.get();
     }
 }
 

--- a/autd3-firmware-emulator/tests/op/cpu_gpio_out.rs
+++ b/autd3-firmware-emulator/tests/op/cpu_gpio_out.rs
@@ -1,3 +1,4 @@
+use autd3_core::link::MsgId;
 use autd3_driver::{datagram::*, firmware::cpu::TxMessage};
 use autd3_firmware_emulator::CPUEmulator;
 
@@ -19,10 +20,11 @@ fn send_cpu_gpio_out(
     let geometry = create_geometry(1);
     let mut cpu = CPUEmulator::new(0, geometry.num_transducers());
     let mut tx = vec![TxMessage::new_zeroed(); 1];
+    let mut msg_id = MsgId::new(0);
 
     let d = CpuGPIOOutputs::new(|_| CpuGPIOPort::new(pa5, pa7));
 
-    assert_eq!(Ok(()), send(&mut cpu, d, &geometry, &mut tx));
+    assert_eq!(Ok(()), send(&mut msg_id, &mut cpu, d, &geometry, &mut tx));
 
     assert_eq!(expect, cpu.port_a_podr());
 

--- a/autd3-firmware-emulator/tests/op/force_fan.rs
+++ b/autd3-firmware-emulator/tests/op/force_fan.rs
@@ -1,3 +1,4 @@
+use autd3_core::link::MsgId;
 use autd3_driver::{datagram::*, firmware::cpu::TxMessage};
 use autd3_firmware_emulator::CPUEmulator;
 
@@ -10,15 +11,16 @@ fn send_force_fan() -> anyhow::Result<()> {
     let geometry = create_geometry(1);
     let mut cpu = CPUEmulator::new(0, geometry.num_transducers());
     let mut tx = vec![TxMessage::new_zeroed(); 1];
+    let mut msg_id = MsgId::new(0);
 
     assert!(!cpu.fpga().is_force_fan());
 
     let d = ForceFan::new(|_dev| true);
-    assert_eq!(Ok(()), send(&mut cpu, d, &geometry, &mut tx));
+    assert_eq!(Ok(()), send(&mut msg_id, &mut cpu, d, &geometry, &mut tx));
     assert!(cpu.fpga().is_force_fan());
 
     let d = ForceFan::new(|_dev| false);
-    assert_eq!(Ok(()), send(&mut cpu, d, &geometry, &mut tx));
+    assert_eq!(Ok(()), send(&mut msg_id, &mut cpu, d, &geometry, &mut tx));
     assert!(!cpu.fpga().is_force_fan());
 
     Ok(())

--- a/autd3-firmware-emulator/tests/op/fpga_gpio_out.rs
+++ b/autd3-firmware-emulator/tests/op/fpga_gpio_out.rs
@@ -1,3 +1,4 @@
+use autd3_core::link::MsgId;
 use autd3_driver::{
     datagram::*,
     ethercat::DcSysTime,
@@ -25,6 +26,7 @@ fn send_debug_output_idx(
     let geometry = create_geometry(1);
     let mut cpu = CPUEmulator::new(0, geometry.num_transducers());
     let mut tx = vec![TxMessage::new_zeroed(); 1];
+    let mut msg_id = MsgId::new(0);
 
     let d = GPIOOutputs::new(|_, gpio| match gpio {
         GPIOOut::O0 => debug_types[0].clone(),
@@ -33,7 +35,7 @@ fn send_debug_output_idx(
         GPIOOut::O3 => debug_types[3].clone(),
     });
 
-    assert_eq!(Ok(()), send(&mut cpu, d, &geometry, &mut tx));
+    assert_eq!(Ok(()), send(&mut msg_id, &mut cpu, d, &geometry, &mut tx));
 
     assert_eq!(expect_types, cpu.fpga().debug_types());
     assert_eq!(expect_values, cpu.fpga().debug_values());
@@ -46,6 +48,7 @@ fn send_debug_pwm_out() -> anyhow::Result<()> {
     let geometry = create_geometry(1);
     let mut cpu = CPUEmulator::new(0, geometry.num_transducers());
     let mut tx = vec![TxMessage::new_zeroed(); 1];
+    let mut msg_id = MsgId::new(0);
 
     let d = GPIOOutputs::new(|dev, gpio| match gpio {
         GPIOOut::O0 => GPIOOutputType::PwmOut(&dev[0]),
@@ -54,7 +57,7 @@ fn send_debug_pwm_out() -> anyhow::Result<()> {
         GPIOOut::O3 => GPIOOutputType::PwmOut(&dev[3]),
     });
 
-    assert_eq!(Ok(()), send(&mut cpu, d, &geometry, &mut tx));
+    assert_eq!(Ok(()), send(&mut msg_id, &mut cpu, d, &geometry, &mut tx));
 
     assert_eq!(
         [DBG_PWM_OUT, DBG_PWM_OUT, DBG_PWM_OUT, DBG_PWM_OUT],

--- a/autd3-firmware-emulator/tests/op/gpio_in.rs
+++ b/autd3-firmware-emulator/tests/op/gpio_in.rs
@@ -1,3 +1,4 @@
+use autd3_core::link::MsgId;
 use autd3_driver::{
     datagram::*,
     firmware::{cpu::TxMessage, fpga::GPIOIn},
@@ -13,15 +14,16 @@ fn send_gpio_in() -> anyhow::Result<()> {
     let geometry = create_geometry(1);
     let mut cpu = CPUEmulator::new(0, geometry.num_transducers());
     let mut tx = vec![TxMessage::new_zeroed(); 1];
+    let mut msg_id = MsgId::new(0);
 
     assert_eq!([false; 4], cpu.fpga().gpio_in());
 
     let d = EmulateGPIOIn::new(|_dev| |gpio| gpio == GPIOIn::I0 || gpio == GPIOIn::I3);
-    assert_eq!(Ok(()), send(&mut cpu, d, &geometry, &mut tx));
+    assert_eq!(Ok(()), send(&mut msg_id, &mut cpu, d, &geometry, &mut tx));
     assert_eq!([true, false, false, true], cpu.fpga().gpio_in());
 
     let d = EmulateGPIOIn::new(|_dev| |gpio| gpio == GPIOIn::I1 || gpio == GPIOIn::I2);
-    assert_eq!(Ok(()), send(&mut cpu, d, &geometry, &mut tx));
+    assert_eq!(Ok(()), send(&mut msg_id, &mut cpu, d, &geometry, &mut tx));
     assert_eq!([false, true, true, false], cpu.fpga().gpio_in());
 
     Ok(())

--- a/autd3-firmware-emulator/tests/op/info.rs
+++ b/autd3-firmware-emulator/tests/op/info.rs
@@ -63,6 +63,7 @@ fn send_firminfo() -> anyhow::Result<()> {
 fn invalid_info_type() -> anyhow::Result<()> {
     let geometry = create_geometry(1);
     let mut cpu = CPUEmulator::new(0, geometry.num_transducers());
+    let mut sent_flags = vec![false; 1];
     let mut tx = vec![TxMessage::new_zeroed(); 1];
     let msg_id = MsgId::new(0);
 
@@ -75,6 +76,7 @@ fn invalid_info_type() -> anyhow::Result<()> {
         msg_id,
         &mut [Some((op, op_null))],
         &geometry,
+        &mut sent_flags,
         &mut tx,
         false,
     )?;

--- a/autd3-firmware-emulator/tests/op/info.rs
+++ b/autd3-firmware-emulator/tests/op/info.rs
@@ -1,3 +1,4 @@
+use autd3_core::link::MsgId;
 use autd3_driver::{
     datagram::*,
     error::AUTDDriverError,
@@ -22,36 +23,37 @@ fn send_firminfo() -> anyhow::Result<()> {
     let geometry = create_geometry(1);
     let mut cpu = CPUEmulator::new(0, geometry.num_transducers());
     let mut tx = vec![TxMessage::new_zeroed(); 1];
+    let mut msg_id = MsgId::new(0);
 
     // configure Reads FPGA Info
     {
         assert!(!cpu.reads_fpga_state());
         let d = ReadsFPGAState::new(|_| true);
-        assert_eq!(Ok(()), send(&mut cpu, d, &geometry, &mut tx));
+        assert_eq!(Ok(()), send(&mut msg_id, &mut cpu, d, &geometry, &mut tx));
         assert!(cpu.reads_fpga_state());
     }
 
-    send(&mut cpu, CPUMajor, &geometry, &mut tx)?;
+    send(&mut msg_id, &mut cpu, CPUMajor, &geometry, &mut tx)?;
     assert_eq!(FirmwareVersion::LATEST_VERSION_NUM_MAJOR.0, cpu.rx().data());
     assert!(!cpu.reads_fpga_state());
 
-    send(&mut cpu, CPUMinor, &geometry, &mut tx)?;
+    send(&mut msg_id, &mut cpu, CPUMinor, &geometry, &mut tx)?;
     assert_eq!(FirmwareVersion::LATEST_VERSION_NUM_MINOR.0, cpu.rx().data());
     assert!(!cpu.reads_fpga_state());
 
-    send(&mut cpu, FPGAMajor, &geometry, &mut tx)?;
+    send(&mut msg_id, &mut cpu, FPGAMajor, &geometry, &mut tx)?;
     assert_eq!(FirmwareVersion::LATEST_VERSION_NUM_MAJOR.0, cpu.rx().data());
     assert!(!cpu.reads_fpga_state());
 
-    send(&mut cpu, FPGAMinor, &geometry, &mut tx)?;
+    send(&mut msg_id, &mut cpu, FPGAMinor, &geometry, &mut tx)?;
     assert_eq!(FirmwareVersion::LATEST_VERSION_NUM_MINOR.0, cpu.rx().data());
     assert!(!cpu.reads_fpga_state());
 
-    send(&mut cpu, FPGAFunctions, &geometry, &mut tx)?;
+    send(&mut msg_id, &mut cpu, FPGAFunctions, &geometry, &mut tx)?;
     assert_eq!(EMULATOR_BIT, cpu.rx().data());
     assert!(!cpu.reads_fpga_state());
 
-    send(&mut cpu, Clear, &geometry, &mut tx)?;
+    send(&mut msg_id, &mut cpu, Clear, &geometry, &mut tx)?;
     assert!(cpu.reads_fpga_state());
 
     Ok(())
@@ -62,13 +64,20 @@ fn invalid_info_type() -> anyhow::Result<()> {
     let geometry = create_geometry(1);
     let mut cpu = CPUEmulator::new(0, geometry.num_transducers());
     let mut tx = vec![TxMessage::new_zeroed(); 1];
+    let msg_id = MsgId::new(0);
 
     let d = FirmwareVersionType::CPUMajor;
     let (op, op_null) = d
         .operation_generator(&geometry, false)?
         .generate(&geometry[0]);
 
-    OperationHandler::pack(&mut [Some((op, op_null))], &geometry, &mut tx, false)?;
+    OperationHandler::pack(
+        msg_id,
+        &mut [Some((op, op_null))],
+        &geometry,
+        &mut tx,
+        false,
+    )?;
     tx[0].payload_mut()[1] = 7;
 
     cpu.send(&tx);

--- a/autd3-firmware-emulator/tests/op/phase_corr.rs
+++ b/autd3-firmware-emulator/tests/op/phase_corr.rs
@@ -1,3 +1,4 @@
+use autd3_core::link::MsgId;
 use autd3_driver::{
     datagram::PhaseCorrection,
     firmware::{cpu::TxMessage, fpga::Phase},
@@ -17,6 +18,7 @@ fn phase_corr_unsafe() -> anyhow::Result<()> {
     let geometry = create_geometry(1);
     let mut cpu = CPUEmulator::new(0, geometry.num_transducers());
     let mut tx = vec![TxMessage::new_zeroed(); 1];
+    let mut msg_id = MsgId::new(0);
 
     let buf: Vec<_> = (0..geometry.num_transducers())
         .map(|_| Phase(rng.random()))
@@ -24,7 +26,7 @@ fn phase_corr_unsafe() -> anyhow::Result<()> {
 
     let d = PhaseCorrection::new(|_| |tr| buf[tr.idx()]);
 
-    assert_eq!(Ok(()), send(&mut cpu, d, &geometry, &mut tx));
+    assert_eq!(Ok(()), send(&mut msg_id, &mut cpu, d, &geometry, &mut tx));
 
     assert_eq!(buf, cpu.fpga().phase_correction());
     assert_eq!(

--- a/autd3-firmware-emulator/tests/op/pulse_width_encoder.rs
+++ b/autd3-firmware-emulator/tests/op/pulse_width_encoder.rs
@@ -1,3 +1,4 @@
+use autd3_core::link::MsgId;
 use autd3_driver::{
     datagram::PulseWidthEncoder,
     firmware::{cpu::TxMessage, fpga::PulseWidth},
@@ -17,6 +18,7 @@ fn config_pwe_unsafe() -> anyhow::Result<()> {
     let geometry = create_geometry(1);
     let mut cpu = CPUEmulator::new(0, geometry.num_transducers());
     let mut tx = vec![TxMessage::new_zeroed(); 1];
+    let mut msg_id = MsgId::new(0);
 
     {
         let buf: Vec<_> = (0..256)
@@ -25,7 +27,7 @@ fn config_pwe_unsafe() -> anyhow::Result<()> {
 
         let d = PulseWidthEncoder::new(|_| |i| buf[i.0 as usize]);
 
-        assert_eq!(Ok(()), send(&mut cpu, d, &geometry, &mut tx));
+        assert_eq!(Ok(()), send(&mut msg_id, &mut cpu, d, &geometry, &mut tx));
 
         assert_eq!(buf, cpu.fpga().pulse_width_encoder_table());
     }
@@ -42,7 +44,7 @@ fn config_pwe_unsafe() -> anyhow::Result<()> {
 
         let d = PulseWidthEncoder::default();
 
-        assert_eq!(Ok(()), send(&mut cpu, d, &geometry, &mut tx));
+        assert_eq!(Ok(()), send(&mut msg_id, &mut cpu, d, &geometry, &mut tx));
 
         assert_eq!(default_table, cpu.fpga().pulse_width_encoder_table());
     }

--- a/autd3-firmware-emulator/tests/op/reads_fpga_state.rs
+++ b/autd3-firmware-emulator/tests/op/reads_fpga_state.rs
@@ -1,3 +1,4 @@
+use autd3_core::link::MsgId;
 use autd3_driver::{
     datagram::*,
     firmware::{
@@ -21,12 +22,13 @@ fn send_reads_fpga_state_unsafe() -> anyhow::Result<()> {
     let geometry = create_geometry(1);
     let mut cpu = CPUEmulator::new(0, geometry.num_transducers());
     let mut tx = vec![TxMessage::new_zeroed(); 1];
+    let mut msg_id = MsgId::new(0);
 
     assert!(!cpu.reads_fpga_state());
 
     let d = ReadsFPGAState::new(|_| true);
 
-    assert_eq!(Ok(()), send(&mut cpu, d, &geometry, &mut tx));
+    assert_eq!(Ok(()), send(&mut msg_id, &mut cpu, d, &geometry, &mut tx));
 
     assert!(cpu.reads_fpga_state());
     assert_eq!(0, cpu.rx().data());
@@ -60,7 +62,7 @@ fn send_reads_fpga_state_unsafe() -> anyhow::Result<()> {
             segment: Segment::S1,
             transition_mode: Some(TransitionMode::Immediate),
         };
-        assert_eq!(Ok(()), send(&mut cpu, d, &geometry, &mut tx));
+        assert_eq!(Ok(()), send(&mut msg_id, &mut cpu, d, &geometry, &mut tx));
 
         let d = WithSegment {
             inner: FociSTM {
@@ -72,7 +74,7 @@ fn send_reads_fpga_state_unsafe() -> anyhow::Result<()> {
             segment: Segment::S1,
             transition_mode: Some(TransitionMode::Immediate),
         };
-        assert_eq!(Ok(()), send(&mut cpu, d, &geometry, &mut tx));
+        assert_eq!(Ok(()), send(&mut msg_id, &mut cpu, d, &geometry, &mut tx));
     }
     cpu.update();
     let state = fpga_state(&cpu);

--- a/autd3-firmware-emulator/tests/op/silener.rs
+++ b/autd3-firmware-emulator/tests/op/silener.rs
@@ -1,5 +1,6 @@
 use std::num::NonZeroU16;
 
+use autd3_core::link::MsgId;
 use autd3_driver::{
     datagram::*,
     error::AUTDDriverError,
@@ -21,6 +22,7 @@ fn send_silencer_fixed_update_rate_unsafe() -> anyhow::Result<()> {
     let geometry = create_geometry(1);
     let mut cpu = CPUEmulator::new(0, geometry.num_transducers());
     let mut tx = vec![TxMessage::new_zeroed(); 1];
+    let mut msg_id = MsgId::new(0);
 
     unsafe {
         let config = FixedUpdateRate {
@@ -29,7 +31,7 @@ fn send_silencer_fixed_update_rate_unsafe() -> anyhow::Result<()> {
         };
         let d = Silencer { config };
 
-        assert_eq!(Ok(()), send(&mut cpu, d, &geometry, &mut tx));
+        assert_eq!(Ok(()), send(&mut msg_id, &mut cpu, d, &geometry, &mut tx));
 
         assert_eq!(config, cpu.fpga().silencer_update_rate());
         assert!(cpu.fpga().silencer_fixed_update_rate_mode());
@@ -42,7 +44,7 @@ fn send_silencer_fixed_update_rate_unsafe() -> anyhow::Result<()> {
         };
         let d = Silencer { config };
 
-        assert_eq!(Ok(()), send(&mut cpu, d, &geometry, &mut tx));
+        assert_eq!(Ok(()), send(&mut msg_id, &mut cpu, d, &geometry, &mut tx));
 
         assert_eq!(config, cpu.fpga().silencer_update_rate());
         assert!(cpu.fpga().silencer_fixed_update_rate_mode());
@@ -60,6 +62,7 @@ fn send_silencer_fixed_completion_time_unsafe() {
     let geometry = create_geometry(1);
     let mut cpu = CPUEmulator::new(0, geometry.num_transducers());
     let mut tx = vec![TxMessage::new_zeroed(); 1];
+    let mut msg_id = MsgId::new(0);
 
     {
         let config = FixedCompletionTime {
@@ -69,7 +72,7 @@ fn send_silencer_fixed_completion_time_unsafe() {
         };
         let d = Silencer { config };
 
-        assert_eq!(Ok(()), send(&mut cpu, d, &geometry, &mut tx));
+        assert_eq!(Ok(()), send(&mut msg_id, &mut cpu, d, &geometry, &mut tx));
 
         assert_eq!(
             (config.intensity.as_nanos() / ULTRASOUND_PERIOD.as_nanos()) as u16,
@@ -90,7 +93,7 @@ fn send_silencer_fixed_completion_time_unsafe() {
             strict_mode: true,
         };
         let d = Silencer { config };
-        assert_eq!(Ok(()), send(&mut cpu, d, &geometry, &mut tx));
+        assert_eq!(Ok(()), send(&mut msg_id, &mut cpu, d, &geometry, &mut tx));
 
         assert_eq!(
             (config.intensity.as_nanos() / ULTRASOUND_PERIOD.as_nanos()) as u16,
@@ -112,6 +115,7 @@ fn send_silencer_fixed_completion_steps_unsafe() {
     let geometry = create_geometry(1);
     let mut cpu = CPUEmulator::new(0, geometry.num_transducers());
     let mut tx = vec![TxMessage::new_zeroed(); 1];
+    let mut msg_id = MsgId::new(0);
 
     {
         let config = FixedCompletionSteps {
@@ -121,7 +125,7 @@ fn send_silencer_fixed_completion_steps_unsafe() {
         };
         let d = Silencer { config };
 
-        assert_eq!(Ok(()), send(&mut cpu, d, &geometry, &mut tx));
+        assert_eq!(Ok(()), send(&mut msg_id, &mut cpu, d, &geometry, &mut tx));
 
         assert_eq!(config, cpu.fpga().silencer_completion_steps());
         assert!(cpu.fpga().silencer_fixed_completion_steps_mode());
@@ -135,7 +139,7 @@ fn send_silencer_fixed_completion_steps_unsafe() {
             strict_mode: true,
         };
         let d = Silencer { config };
-        assert_eq!(Ok(()), send(&mut cpu, d, &geometry, &mut tx));
+        assert_eq!(Ok(()), send(&mut msg_id, &mut cpu, d, &geometry, &mut tx));
 
         assert_eq!(config, cpu.fpga().silencer_completion_steps());
         assert!(cpu.fpga().silencer_fixed_completion_steps_mode());
@@ -156,6 +160,7 @@ fn silencer_completetion_steps_too_large_mod(
     let geometry = create_geometry(1);
     let mut cpu = CPUEmulator::new(0, geometry.num_transducers());
     let mut tx = vec![TxMessage::new_zeroed(); 1];
+    let mut msg_id = MsgId::new(0);
 
     let d = Silencer {
         config: FixedCompletionSteps {
@@ -164,7 +169,7 @@ fn silencer_completetion_steps_too_large_mod(
             strict_mode: true,
         },
     };
-    assert_eq!(Ok(()), send(&mut cpu, d, &geometry, &mut tx));
+    assert_eq!(Ok(()), send(&mut msg_id, &mut cpu, d, &geometry, &mut tx));
 
     // Send modulation
     {
@@ -173,7 +178,7 @@ fn silencer_completetion_steps_too_large_mod(
             sampling_config: SamplingConfig::FREQ_40K,
         };
 
-        assert_eq!(Ok(()), send(&mut cpu, d, &geometry, &mut tx));
+        assert_eq!(Ok(()), send(&mut msg_id, &mut cpu, d, &geometry, &mut tx));
     }
 
     let steps_phase = 1;
@@ -185,7 +190,7 @@ fn silencer_completetion_steps_too_large_mod(
         },
     };
 
-    assert_eq!(expect, send(&mut cpu, d, &geometry, &mut tx));
+    assert_eq!(expect, send(&mut msg_id, &mut cpu, d, &geometry, &mut tx));
 
     Ok(())
 }
@@ -203,6 +208,7 @@ fn silencer_completetion_steps_too_large_stm(
     let geometry = create_geometry(1);
     let mut cpu = CPUEmulator::new(0, geometry.num_transducers());
     let mut tx = vec![TxMessage::new_zeroed(); 1];
+    let mut msg_id = MsgId::new(0);
 
     let d = Silencer {
         config: FixedCompletionSteps {
@@ -211,7 +217,7 @@ fn silencer_completetion_steps_too_large_stm(
             strict_mode: true,
         },
     };
-    assert_eq!(Ok(()), send(&mut cpu, d, &geometry, &mut tx));
+    assert_eq!(Ok(()), send(&mut msg_id, &mut cpu, d, &geometry, &mut tx));
 
     // Send FociSTM
     {
@@ -220,7 +226,7 @@ fn silencer_completetion_steps_too_large_stm(
             config: SamplingConfig::FREQ_40K,
         };
 
-        assert_eq!(Ok(()), send(&mut cpu, d, &geometry, &mut tx));
+        assert_eq!(Ok(()), send(&mut msg_id, &mut cpu, d, &geometry, &mut tx));
     }
 
     let d = Silencer {
@@ -231,7 +237,7 @@ fn silencer_completetion_steps_too_large_stm(
         },
     };
 
-    assert_eq!(expect, send(&mut cpu, d, &geometry, &mut tx));
+    assert_eq!(expect, send(&mut msg_id, &mut cpu, d, &geometry, &mut tx));
 
     Ok(())
 }
@@ -243,6 +249,7 @@ fn send_silencer_fixed_completion_steps_permissive() -> anyhow::Result<()> {
     let geometry = create_geometry(1);
     let mut cpu = CPUEmulator::new(0, geometry.num_transducers());
     let mut tx = vec![TxMessage::new_zeroed(); 1];
+    let mut msg_id = MsgId::new(0);
 
     let config = FixedCompletionSteps {
         intensity: NonZeroU16::new(rng.random_range(1..=u16::MAX)).unwrap(),
@@ -251,7 +258,7 @@ fn send_silencer_fixed_completion_steps_permissive() -> anyhow::Result<()> {
     };
     let d = Silencer { config };
 
-    assert_eq!(Ok(()), send(&mut cpu, d, &geometry, &mut tx));
+    assert_eq!(Ok(()), send(&mut msg_id, &mut cpu, d, &geometry, &mut tx));
 
     assert_eq!(
         config.intensity,
@@ -271,6 +278,7 @@ fn send_silencer_fixed_completion_time_permissive() {
     let geometry = create_geometry(1);
     let mut cpu = CPUEmulator::new(0, geometry.num_transducers());
     let mut tx = vec![TxMessage::new_zeroed(); 1];
+    let mut msg_id = MsgId::new(0);
 
     let config = FixedCompletionSteps {
         intensity: NonZeroU16::new(rng.random_range(1..=u16::MAX)).unwrap(),
@@ -279,7 +287,7 @@ fn send_silencer_fixed_completion_time_permissive() {
     };
     let d = Silencer { config };
 
-    assert_eq!(Ok(()), send(&mut cpu, d, &geometry, &mut tx));
+    assert_eq!(Ok(()), send(&mut msg_id, &mut cpu, d, &geometry, &mut tx));
 
     assert_eq!(
         config.intensity,

--- a/autd3-firmware-emulator/tests/op/stm/foci.rs
+++ b/autd3-firmware-emulator/tests/op/stm/foci.rs
@@ -1,3 +1,4 @@
+use autd3_core::link::MsgId;
 use std::{collections::HashMap, num::NonZeroU16, time::Duration};
 
 use autd3_core::gain::EmitIntensity;
@@ -74,13 +75,14 @@ fn test_send_foci_stm_unsafe(
     geometry.set_sound_speed(400e3);
     let mut cpu = CPUEmulator::new(0, geometry.num_transducers());
     let mut tx = vec![TxMessage::new_zeroed(); 1];
+    let mut msg_id = MsgId::new(0);
 
     let phase_corr: Vec<_> = (0..geometry.num_transducers())
         .map(|_| Phase(rng.random()))
         .collect();
     {
         let d = PhaseCorrection::new(|_| |tr| phase_corr[tr.idx()]);
-        assert_eq!(Ok(()), send(&mut cpu, d, &geometry, &mut tx));
+        assert_eq!(Ok(()), send(&mut msg_id, &mut cpu, d, &geometry, &mut tx));
     }
 
     let freq_div = rng.random_range(
@@ -98,7 +100,7 @@ fn test_send_foci_stm_unsafe(
         transition_mode,
     };
 
-    assert_eq!(Ok(()), send(&mut cpu, stm, &geometry, &mut tx));
+    assert_eq!(Ok(()), send(&mut msg_id, &mut cpu, stm, &geometry, &mut tx));
 
     assert!(!cpu.fpga().is_stm_gain_mode(segment));
     assert_eq!(loop_behavior, cpu.fpga().stm_loop_behavior(segment));
@@ -143,6 +145,7 @@ fn change_foci_stm_segment_unsafe() -> anyhow::Result<()> {
     let geometry = create_geometry(1);
     let mut cpu = CPUEmulator::new(0, geometry.num_transducers());
     let mut tx = vec![TxMessage::new_zeroed(); 1];
+    let mut msg_id = MsgId::new(0);
 
     assert!(cpu.fpga().is_stm_gain_mode(Segment::S1));
     assert_eq!(Segment::S0, cpu.fpga().req_stm_segment());
@@ -156,12 +159,12 @@ fn change_foci_stm_segment_unsafe() -> anyhow::Result<()> {
         transition_mode: None,
     };
 
-    assert_eq!(Ok(()), send(&mut cpu, stm, &geometry, &mut tx));
+    assert_eq!(Ok(()), send(&mut msg_id, &mut cpu, stm, &geometry, &mut tx));
     assert!(!cpu.fpga().is_stm_gain_mode(Segment::S1));
     assert_eq!(Segment::S0, cpu.fpga().req_stm_segment());
 
     let d = SwapSegment::FociSTM(Segment::S1, TransitionMode::Immediate);
-    assert_eq!(Ok(()), send(&mut cpu, d, &geometry, &mut tx));
+    assert_eq!(Ok(()), send(&mut msg_id, &mut cpu, d, &geometry, &mut tx));
     assert!(!cpu.fpga().is_stm_gain_mode(Segment::S1));
     assert_eq!(Segment::S1, cpu.fpga().req_stm_segment());
 
@@ -173,6 +176,7 @@ fn test_foci_stm_freq_div_too_small() -> anyhow::Result<()> {
     let geometry = create_geometry(1);
     let mut cpu = CPUEmulator::new(0, geometry.num_transducers());
     let mut tx = vec![TxMessage::new_zeroed(); 1];
+    let mut msg_id = MsgId::new(0);
 
     {
         let stm = FociSTM {
@@ -182,7 +186,7 @@ fn test_foci_stm_freq_div_too_small() -> anyhow::Result<()> {
 
         assert_eq!(
             Err(AUTDDriverError::InvalidSilencerSettings),
-            send(&mut cpu, stm, &geometry, &mut tx)
+            send(&mut msg_id, &mut cpu, stm, &geometry, &mut tx)
         );
     }
 
@@ -193,10 +197,10 @@ fn test_foci_stm_freq_div_too_small() -> anyhow::Result<()> {
                 .map(|dev| (dev.idx(), dev.iter().map(|_| Drive::NULL).collect()))
                 .collect(),
         };
-        assert_eq!(Ok(()), send(&mut cpu, g, &geometry, &mut tx));
+        assert_eq!(Ok(()), send(&mut msg_id, &mut cpu, g, &geometry, &mut tx));
 
         let d = Silencer::<FixedCompletionSteps>::default();
-        assert_eq!(Ok(()), send(&mut cpu, d, &geometry, &mut tx));
+        assert_eq!(Ok(()), send(&mut msg_id, &mut cpu, d, &geometry, &mut tx));
 
         let stm = WithSegment {
             inner: FociSTM {
@@ -212,7 +216,7 @@ fn test_foci_stm_freq_div_too_small() -> anyhow::Result<()> {
             transition_mode: None,
         };
 
-        assert_eq!(Ok(()), send(&mut cpu, stm, &geometry, &mut tx));
+        assert_eq!(Ok(()), send(&mut msg_id, &mut cpu, stm, &geometry, &mut tx));
 
         let d = Silencer {
             config: FixedCompletionSteps {
@@ -221,12 +225,12 @@ fn test_foci_stm_freq_div_too_small() -> anyhow::Result<()> {
                 strict_mode: true,
             },
         };
-        assert_eq!(Ok(()), send(&mut cpu, d, &geometry, &mut tx));
+        assert_eq!(Ok(()), send(&mut msg_id, &mut cpu, d, &geometry, &mut tx));
 
         let d = SwapSegment::FociSTM(Segment::S1, TransitionMode::Immediate);
         assert_eq!(
             Err(AUTDDriverError::InvalidSilencerSettings),
-            send(&mut cpu, d, &geometry, &mut tx)
+            send(&mut msg_id, &mut cpu, d, &geometry, &mut tx)
         );
     }
 
@@ -238,6 +242,7 @@ fn send_foci_stm_invalid_segment_transition() -> anyhow::Result<()> {
     let geometry = create_geometry(1);
     let mut cpu = CPUEmulator::new(0, geometry.num_transducers());
     let mut tx = vec![TxMessage::new_zeroed(); 1];
+    let mut msg_id = MsgId::new(0);
 
     // segment 0: Gain
     {
@@ -247,7 +252,7 @@ fn send_foci_stm_invalid_segment_transition() -> anyhow::Result<()> {
             .collect();
         let g = TestGain { data: buf.clone() };
 
-        assert_eq!(Ok(()), send(&mut cpu, g, &geometry, &mut tx));
+        assert_eq!(Ok(()), send(&mut msg_id, &mut cpu, g, &geometry, &mut tx));
     }
 
     // segment 1: GainSTM
@@ -273,20 +278,20 @@ fn send_foci_stm_invalid_segment_transition() -> anyhow::Result<()> {
             transition_mode: Some(TransitionMode::Immediate),
         };
 
-        assert_eq!(Ok(()), send(&mut cpu, stm, &geometry, &mut tx));
+        assert_eq!(Ok(()), send(&mut msg_id, &mut cpu, stm, &geometry, &mut tx));
     }
 
     {
         let d = SwapSegment::FociSTM(Segment::S0, TransitionMode::Immediate);
         assert_eq!(
             Err(AUTDDriverError::InvalidSegmentTransition),
-            send(&mut cpu, d, &geometry, &mut tx)
+            send(&mut msg_id, &mut cpu, d, &geometry, &mut tx)
         );
 
         let d = SwapSegment::FociSTM(Segment::S1, TransitionMode::Immediate);
         assert_eq!(
             Err(AUTDDriverError::InvalidSegmentTransition),
-            send(&mut cpu, d, &geometry, &mut tx)
+            send(&mut msg_id, &mut cpu, d, &geometry, &mut tx)
         );
     }
 
@@ -298,6 +303,7 @@ fn send_foci_stm_invalid_transition_mode() -> anyhow::Result<()> {
     let geometry = create_geometry(1);
     let mut cpu = CPUEmulator::new(0, geometry.num_transducers());
     let mut tx = vec![TxMessage::new_zeroed(); 1];
+    let mut msg_id = MsgId::new(0);
 
     // segment 0 to 0
     {
@@ -311,7 +317,7 @@ fn send_foci_stm_invalid_transition_mode() -> anyhow::Result<()> {
         };
         assert_eq!(
             Err(AUTDDriverError::InvalidTransitionMode),
-            send(&mut cpu, stm, &geometry, &mut tx)
+            send(&mut msg_id, &mut cpu, stm, &geometry, &mut tx)
         );
     }
 
@@ -328,7 +334,7 @@ fn send_foci_stm_invalid_transition_mode() -> anyhow::Result<()> {
         };
         assert_eq!(
             Err(AUTDDriverError::InvalidTransitionMode),
-            send(&mut cpu, stm, &geometry, &mut tx)
+            send(&mut msg_id, &mut cpu, stm, &geometry, &mut tx)
         );
     }
 
@@ -343,12 +349,12 @@ fn send_foci_stm_invalid_transition_mode() -> anyhow::Result<()> {
             transition_mode: None,
         };
 
-        assert_eq!(Ok(()), send(&mut cpu, stm, &geometry, &mut tx));
+        assert_eq!(Ok(()), send(&mut msg_id, &mut cpu, stm, &geometry, &mut tx));
 
         let d = SwapSegment::FociSTM(Segment::S1, TransitionMode::SyncIdx);
         assert_eq!(
             Err(AUTDDriverError::InvalidTransitionMode),
-            send(&mut cpu, d, &geometry, &mut tx)
+            send(&mut msg_id, &mut cpu, d, &geometry, &mut tx)
         );
     }
 
@@ -368,6 +374,7 @@ fn test_miss_transition_time(
     let geometry = create_geometry(1);
     let mut cpu = CPUEmulator::new(0, geometry.num_transducers());
     let mut tx = vec![TxMessage::new_zeroed(); 1];
+    let mut msg_id = MsgId::new(0);
 
     let transition_mode = TransitionMode::SysTime(DcSysTime::from_utc(transition_time).unwrap());
 
@@ -382,7 +389,7 @@ fn test_miss_transition_time(
     };
 
     cpu.update_with_sys_time(DcSysTime::from_utc(systime).unwrap());
-    assert_eq!(expect, send(&mut cpu, stm, &geometry, &mut tx));
+    assert_eq!(expect, send(&mut msg_id, &mut cpu, stm, &geometry, &mut tx));
     if expect.is_ok() {
         assert_eq!(transition_mode, cpu.fpga().stm_transition_mode());
     }
@@ -400,6 +407,7 @@ fn test_send_foci_stm_n<const N: usize>() -> anyhow::Result<()> {
     geometry.set_sound_speed(400e3);
     let mut cpu = CPUEmulator::new(0, geometry.num_transducers());
     let mut tx = vec![TxMessage::new_zeroed(); 1];
+    let mut msg_id = MsgId::new(0);
 
     {
         let freq_div = rng.random_range(
@@ -420,7 +428,7 @@ fn test_send_foci_stm_n<const N: usize>() -> anyhow::Result<()> {
             transition_mode: Some(transition_mode),
         };
 
-        assert_eq!(Ok(()), send(&mut cpu, stm, &geometry, &mut tx));
+        assert_eq!(Ok(()), send(&mut msg_id, &mut cpu, stm, &geometry, &mut tx));
 
         assert!(!cpu.fpga().is_stm_gain_mode(Segment::S0));
         assert_eq!(segment, cpu.fpga().req_stm_segment());

--- a/autd3-firmware-emulator/tests/op/stm/gain.rs
+++ b/autd3-firmware-emulator/tests/op/stm/gain.rs
@@ -499,6 +499,7 @@ fn send_gain_stm_invalid_transition_mode() -> anyhow::Result<()> {
 fn invalid_gain_stm_mode() -> anyhow::Result<()> {
     let geometry = create_geometry(1);
     let mut cpu = CPUEmulator::new(0, geometry.num_transducers());
+    let mut sent_flags = vec![false; 1];
     let mut tx = vec![TxMessage::new_zeroed(); 1];
     let msg_id = MsgId::new(0);
 
@@ -514,7 +515,7 @@ fn invalid_gain_stm_mode() -> anyhow::Result<()> {
 
     let generator = d.operation_generator(&geometry, false)?;
     let mut op = OperationHandler::generate(generator, &geometry);
-    OperationHandler::pack(msg_id, &mut op, &geometry, &mut tx, false)?;
+    OperationHandler::pack(msg_id, &mut op, &geometry, &mut sent_flags, &mut tx, false)?;
     tx[0].payload_mut()[2] = 3;
 
     cpu.send(&tx);

--- a/autd3-firmware-emulator/tests/op/sync.rs
+++ b/autd3-firmware-emulator/tests/op/sync.rs
@@ -1,3 +1,4 @@
+use autd3_core::link::MsgId;
 use autd3_driver::{datagram::*, firmware::cpu::TxMessage};
 use autd3_firmware_emulator::CPUEmulator;
 
@@ -14,7 +15,10 @@ fn send_sync() -> anyhow::Result<()> {
     let d = Synchronize::new();
     assert!(!cpu.synchronized());
 
-    assert_eq!(Ok(()), send(&mut cpu, d, &geometry, &mut tx));
+    assert_eq!(
+        Ok(()),
+        send(&mut MsgId::new(0), &mut cpu, d, &geometry, &mut tx)
+    );
 
     assert!(cpu.synchronized());
 

--- a/autd3-firmware-emulator/tests/test.rs
+++ b/autd3-firmware-emulator/tests/test.rs
@@ -1,4 +1,4 @@
-use autd3_core::datagram::Operation;
+use autd3_core::{datagram::Operation, link::MsgId};
 use autd3_driver::{
     autd3_device::AUTD3,
     datagram::*,
@@ -29,6 +29,7 @@ pub fn create_geometry(n: usize) -> Geometry {
 }
 
 pub fn send<D>(
+    msg_id: &mut MsgId,
     cpu: &mut CPUEmulator,
     d: D,
     geometry: &Geometry,
@@ -49,12 +50,13 @@ where
         if OperationHandler::is_done(&op) {
             break;
         }
-        OperationHandler::pack(&mut op, geometry, tx, parallel)?;
+        msg_id.increment();
+        OperationHandler::pack(*msg_id, &mut op, geometry, tx, parallel)?;
         cpu.send(tx);
         if (cpu.rx().ack() & ERR_BIT) == ERR_BIT {
             return Err(AUTDDriverError::firmware_err(cpu.rx().ack()));
         }
-        assert_eq!(tx[0].header.msg_id, cpu.rx().ack());
+        assert_eq!(tx[0].header.msg_id.get(), cpu.rx().ack());
     }
     Ok(())
 }
@@ -65,7 +67,7 @@ fn send_invalid_tag() {
     let mut cpu = CPUEmulator::new(0, geometry.num_transducers());
     let mut tx = vec![TxMessage::new_zeroed(); 1];
 
-    tx[0].header.msg_id = 1;
+    tx[0].header.msg_id = MsgId::new(1);
     tx[0].payload_mut()[0] = 0xFF;
 
     cpu.send(&tx);
@@ -81,7 +83,7 @@ fn send_invalid_msg_id() {
     let mut cpu = CPUEmulator::new(0, geometry.num_transducers());
     let mut tx = vec![TxMessage::new_zeroed(); 1];
 
-    tx[0].header.msg_id = 0x80;
+    tx[0].header.msg_id = MsgId::new(0x80);
 
     cpu.send(&tx);
     assert_eq!(
@@ -95,20 +97,19 @@ fn send_ingore_same_data() -> anyhow::Result<()> {
     let geometry = create_geometry(1);
     let mut cpu = CPUEmulator::new(0, geometry.num_transducers());
     let mut tx = vec![TxMessage::new_zeroed(); 1];
+    let msg_id = MsgId::new(0x10);
 
     let d = Clear::new();
     let generator = d.operation_generator(&geometry, false)?;
     let mut op = OperationHandler::generate(generator, &geometry);
-    OperationHandler::pack(&mut op, &geometry, &mut tx, false)?;
+    OperationHandler::pack(msg_id, &mut op, &geometry, &mut tx, false)?;
     cpu.send(&tx);
-    let msg_id = tx[0].header.msg_id;
-    assert_eq!(cpu.rx().ack(), tx[0].header.msg_id);
+    assert_eq!(cpu.rx().ack(), tx[0].header.msg_id.get());
 
     let d = Synchronize::new();
     let generator = d.operation_generator(&geometry, false)?;
     let mut op = OperationHandler::generate(generator, &geometry);
-    OperationHandler::pack(&mut op, &geometry, &mut tx, false)?;
-    tx[0].header.msg_id = msg_id;
+    OperationHandler::pack(msg_id, &mut op, &geometry, &mut tx, false)?;
     assert!(!cpu.synchronized());
     cpu.send(&tx);
     assert!(!cpu.synchronized());
@@ -121,15 +122,16 @@ fn send_slot_2_unsafe() -> anyhow::Result<()> {
     let geometry = create_geometry(1);
     let mut cpu = CPUEmulator::new(0, geometry.num_transducers());
     let mut tx = vec![TxMessage::new_zeroed(); 1];
+    let msg_id = MsgId::new(0x12);
 
     let d = (Clear::new(), Synchronize::new());
     let generator = d.operation_generator(&geometry, false)?;
     let mut op = OperationHandler::generate(generator, &geometry);
-    OperationHandler::pack(&mut op, &geometry, &mut tx, false)?;
+    OperationHandler::pack(msg_id, &mut op, &geometry, &mut tx, false)?;
 
     assert!(!cpu.synchronized());
     cpu.send(&tx);
-    assert_eq!(cpu.rx().ack(), tx[0].header.msg_id);
+    assert_eq!(cpu.rx().ack(), tx[0].header.msg_id.get());
     assert!(cpu.synchronized());
 
     Ok(())
@@ -140,11 +142,12 @@ fn send_slot_2_err() -> anyhow::Result<()> {
     let geometry = create_geometry(1);
     let mut cpu = CPUEmulator::new(0, geometry.num_transducers());
     let mut tx = vec![TxMessage::new_zeroed(); 1];
+    let msg_id = MsgId::new(0);
 
     let d = (Clear::new(), Synchronize::new());
     let generator = d.operation_generator(&geometry, false)?;
     let mut op = OperationHandler::generate(generator, &geometry);
-    OperationHandler::pack(&mut op, &geometry, &mut tx, false)?;
+    OperationHandler::pack(msg_id, &mut op, &geometry, &mut tx, false)?;
 
     let slot2_offset = tx[0].header.slot_2_offset as usize;
     tx[0].payload_mut()[slot2_offset] = 0xFF;

--- a/autd3-link-simulator/Cargo.toml
+++ b/autd3-link-simulator/Cargo.toml
@@ -15,9 +15,10 @@ autd3-core = { workspace = true, features = ["link", "async"] }
 tonic = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true, optional = true, features = ["rt-multi-thread"] }
+zerocopy = { workspace = true }
 
 [features]
-default = []
+default = ["blocking"]
 blocking = ["tokio"]
 async-trait = ["autd3-core/async-trait", "autd3-protobuf/async-trait"]
 

--- a/autd3-link-simulator/src/lib.rs
+++ b/autd3-link-simulator/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! [`AUTD3 Simulator`]: https://github.com/shinolab/autd3-server
 
-use autd3_core::link::{AsyncLink, LinkError, RxMessage, TxMessage};
+use autd3_core::link::{AsyncLink, LinkError, RxMessage, TxBufferPoolSync, TxMessage};
 
 use autd3_protobuf::*;
 
@@ -16,6 +16,7 @@ use std::net::SocketAddr;
 struct SimulatorInner {
     client: simulator_client::SimulatorClient<tonic::transport::Channel>,
     last_geometry_version: usize,
+    buffer_pool: TxBufferPoolSync,
 }
 
 impl SimulatorInner {
@@ -39,9 +40,13 @@ impl SimulatorInner {
                 AUTDProtoBufError::SendError("Failed to initialize simulator".to_string())
             })?;
 
+        let mut buffer_pool = TxBufferPoolSync::default();
+        buffer_pool.init(geometry);
+
         Ok(Self {
             client,
             last_geometry_version: geometry.version(),
+            buffer_pool,
         })
     }
 
@@ -69,11 +74,18 @@ impl SimulatorInner {
         Ok(())
     }
 
-    async fn send(&mut self, tx: &[TxMessage]) -> Result<(), LinkError> {
-        self.client
-            .send_data(TxRawData::from(tx))
+    fn alloc_tx_buffer(&mut self) -> Vec<TxMessage> {
+        self.buffer_pool.borrow()
+    }
+
+    async fn send(&mut self, tx: Vec<TxMessage>) -> Result<(), LinkError> {
+        let r = self
+            .client
+            .send_data(TxRawData::from(tx.as_slice()))
             .await
-            .map_err(AUTDProtoBufError::from)?;
+            .map_err(AUTDProtoBufError::from);
+        self.buffer_pool.return_buffer(tx);
+        r?;
         Ok(())
     }
 
@@ -98,6 +110,7 @@ impl SimulatorInner {
 ///
 /// [`AUTD3 Simulator`]: https://github.com/shinolab/autd3-server
 pub struct Simulator {
+    num_devices: usize,
     addr: SocketAddr,
     inner: Option<SimulatorInner>,
     #[cfg(feature = "blocking")]
@@ -109,6 +122,7 @@ impl Simulator {
     #[must_use]
     pub const fn new(addr: SocketAddr) -> Simulator {
         Simulator {
+            num_devices: 0,
             addr,
             inner: None,
             #[cfg(feature = "blocking")]
@@ -121,6 +135,7 @@ impl Simulator {
 impl AsyncLink for Simulator {
     async fn open(&mut self, geometry: &autd3_core::geometry::Geometry) -> Result<(), LinkError> {
         self.inner = Some(SimulatorInner::open(&self.addr, geometry).await?);
+        self.num_devices = geometry.len();
         Ok(())
     }
 
@@ -140,7 +155,15 @@ impl AsyncLink for Simulator {
         }
     }
 
-    async fn send(&mut self, tx: &[TxMessage]) -> Result<(), LinkError> {
+    async fn alloc_tx_buffer(&mut self) -> Vec<TxMessage> {
+        if let Some(inner) = self.inner.as_mut() {
+            inner.alloc_tx_buffer()
+        } else {
+            vec![]
+        }
+    }
+
+    async fn send(&mut self, tx: Vec<TxMessage>) -> Result<(), LinkError> {
         if let Some(inner) = self.inner.as_mut() {
             inner.send(tx).await?;
             Ok(())
@@ -205,7 +228,19 @@ impl Link for Simulator {
             })
     }
 
-    fn send(&mut self, tx: &[TxMessage]) -> Result<(), LinkError> {
+    fn alloc_tx_buffer(&mut self) -> Vec<TxMessage> {
+        self.runtime.as_ref().map_or(vec![], |runtime| {
+            runtime.block_on(async {
+                if let Some(inner) = self.inner.as_mut() {
+                    inner.alloc_tx_buffer()
+                } else {
+                    vec![]
+                }
+            })
+        })
+    }
+
+    fn send(&mut self, tx: Vec<TxMessage>) -> Result<(), LinkError> {
         self.runtime
             .as_ref()
             .map_or(Err(LinkError::new("Link is closed")), |runtime| {

--- a/autd3-link-twincat/src/local/mod.rs
+++ b/autd3-link-twincat/src/local/mod.rs
@@ -8,7 +8,7 @@ use zerocopy::IntoBytes;
 
 use autd3_core::{
     geometry::Geometry,
-    link::{Link, LinkError, RxMessage, TxMessage},
+    link::{Link, LinkError, RxMessage, TxBufferPoolSync, TxMessage},
 };
 
 #[repr(C)]
@@ -38,6 +38,7 @@ const PORT: u16 = 301;
 pub struct TwinCAT {
     port: i32,
     send_addr: AmsAddr,
+    buffer_pool: TxBufferPoolSync,
     dll: Library,
 }
 
@@ -50,13 +51,14 @@ impl TwinCAT {
                 net_id: AmsNetId { b: [0; 6] },
                 port: 0,
             },
+            buffer_pool: TxBufferPoolSync::default(),
             dll: unsafe { lib::Library::new("TcAdsDll") }.map_err(|_| AdsError::DllNotFound)?,
         })
     }
 }
 
 impl Link for TwinCAT {
-    fn open(&mut self, _: &Geometry) -> Result<(), LinkError> {
+    fn open(&mut self, geometry: &Geometry) -> Result<(), LinkError> {
         let port = unsafe {
             self.dll
                 .get::<unsafe extern "C" fn() -> i32>(b"AdsPortOpenEx")
@@ -84,6 +86,9 @@ impl Link for TwinCAT {
             net_id: ams_addr.net_id,
             port: PORT,
         };
+
+        self.buffer_pool.init(geometry);
+
         Ok(())
     }
 
@@ -99,7 +104,11 @@ impl Link for TwinCAT {
         Ok(())
     }
 
-    fn send(&mut self, tx: &[TxMessage]) -> Result<(), LinkError> {
+    fn alloc_tx_buffer(&mut self) -> Vec<TxMessage> {
+        self.buffer_pool.borrow()
+    }
+
+    fn send(&mut self, tx: Vec<TxMessage>) -> Result<(), LinkError> {
         unsafe {
             let n_err = self.dll.get::<unsafe extern "C" fn(
                 i32,
@@ -121,6 +130,8 @@ impl Link for TwinCAT {
                     tx.as_bytes().len() as _,
                     tx.as_ptr() as _,
             );
+
+            self.buffer_pool.return_buffer(tx);
 
             if n_err > 0 {
                 Err(AdsError::SendData(n_err).into())
@@ -182,7 +193,11 @@ impl AsyncLink for TwinCAT {
         <Self as Link>::close(self)
     }
 
-    async fn send(&mut self, tx: &[TxMessage]) -> Result<(), LinkError> {
+    async fn alloc_tx_buffer(&mut self) -> Vec<TxMessage> {
+        <Self as Link>::alloc_tx_buffer(self)
+    }
+
+    async fn send(&mut self, tx: Vec<TxMessage>) -> Result<(), LinkError> {
         <Self as Link>::send(self, tx)
     }
 

--- a/autd3-link-twincat/src/local/mod.rs
+++ b/autd3-link-twincat/src/local/mod.rs
@@ -104,8 +104,8 @@ impl Link for TwinCAT {
         Ok(())
     }
 
-    fn alloc_tx_buffer(&mut self) -> Vec<TxMessage> {
-        self.buffer_pool.borrow()
+    fn alloc_tx_buffer(&mut self) -> Result<Vec<TxMessage>, LinkError> {
+        Ok(self.buffer_pool.borrow())
     }
 
     fn send(&mut self, tx: Vec<TxMessage>) -> Result<(), LinkError> {
@@ -193,7 +193,7 @@ impl AsyncLink for TwinCAT {
         <Self as Link>::close(self)
     }
 
-    async fn alloc_tx_buffer(&mut self) -> Vec<TxMessage> {
+    async fn alloc_tx_buffer(&mut self) -> Result<Vec<TxMessage>, LinkError> {
         <Self as Link>::alloc_tx_buffer(self)
     }
 

--- a/autd3-link-twincat/src/remote/remote_twincat_link.rs
+++ b/autd3-link-twincat/src/remote/remote_twincat_link.rs
@@ -148,8 +148,8 @@ impl Link for RemoteTwinCAT {
         Ok(())
     }
 
-    fn alloc_tx_buffer(&mut self) -> Vec<TxMessage> {
-        self.buffer_pool.borrow()
+    fn alloc_tx_buffer(&mut self) -> Result<Vec<TxMessage>, LinkError> {
+        Ok(self.buffer_pool.borrow())
     }
 
     fn send(&mut self, tx: Vec<TxMessage>) -> Result<(), LinkError> {
@@ -225,7 +225,7 @@ impl AsyncLink for RemoteTwinCAT {
         <Self as Link>::close(self)
     }
 
-    async fn alloc_tx_buffer(&mut self) -> Vec<TxMessage> {
+    async fn alloc_tx_buffer(&mut self) -> Result<Vec<TxMessage>, LinkError> {
         <Self as Link>::alloc_tx_buffer(self)
     }
 

--- a/autd3-link-twincat/src/remote/remote_twincat_link.rs
+++ b/autd3-link-twincat/src/remote/remote_twincat_link.rs
@@ -6,7 +6,7 @@ use zerocopy::IntoBytes;
 
 use autd3_core::{
     geometry::Geometry,
-    link::{Link, LinkError, RxMessage, TxMessage},
+    link::{Link, LinkError, RxMessage, TxBufferPoolSync, TxMessage},
 };
 
 use crate::{error::AdsError, remote::native_methods::*};
@@ -26,6 +26,7 @@ pub struct RemoteTwinCAT {
     option: RemoteTwinCATOption,
     port: c_long,
     net_id: AmsNetId,
+    buffer_pool: TxBufferPoolSync,
 }
 
 /// The option of [`RemoteTwinCAT`].
@@ -46,12 +47,13 @@ impl RemoteTwinCAT {
             option,
             port: 0,
             net_id: AmsNetId { b: [0; 6] },
+            buffer_pool: TxBufferPoolSync::default(),
         }
     }
 }
 
 impl Link for RemoteTwinCAT {
-    fn open(&mut self, _: &Geometry) -> Result<(), LinkError> {
+    fn open(&mut self, geometry: &Geometry) -> Result<(), LinkError> {
         tracing::info!("Connecting to TwinCAT3");
 
         let RemoteTwinCATOption {
@@ -125,6 +127,8 @@ impl Link for RemoteTwinCAT {
         self.port = port;
         self.net_id = net_id;
 
+        self.buffer_pool.init(geometry);
+
         Ok(())
     }
 
@@ -144,7 +148,11 @@ impl Link for RemoteTwinCAT {
         Ok(())
     }
 
-    fn send(&mut self, tx: &[TxMessage]) -> Result<(), LinkError> {
+    fn alloc_tx_buffer(&mut self) -> Vec<TxMessage> {
+        self.buffer_pool.borrow()
+    }
+
+    fn send(&mut self, tx: Vec<TxMessage>) -> Result<(), LinkError> {
         let addr = AmsAddr {
             net_id: self.net_id,
             port: PORT,
@@ -160,6 +168,8 @@ impl Link for RemoteTwinCAT {
                 tx.as_ptr() as _,
             )
         };
+
+        self.buffer_pool.return_buffer(tx);
 
         if res == 0 {
             return Ok(());
@@ -215,7 +225,11 @@ impl AsyncLink for RemoteTwinCAT {
         <Self as Link>::close(self)
     }
 
-    async fn send(&mut self, tx: &[TxMessage]) -> Result<(), LinkError> {
+    async fn alloc_tx_buffer(&mut self) -> Vec<TxMessage> {
+        <Self as Link>::alloc_tx_buffer(self)
+    }
+
+    async fn send(&mut self, tx: Vec<TxMessage>) -> Result<(), LinkError> {
         <Self as Link>::send(self, tx)
     }
 

--- a/autd3-protobuf/src/traits/driver/firmware/cpu/datagram/tx.rs
+++ b/autd3-protobuf/src/traits/driver/firmware/cpu/datagram/tx.rs
@@ -31,7 +31,7 @@ mod tests {
         let mut rng = rand::rng();
         let mut tx = vec![autd3_driver::firmware::cpu::TxMessage::new_zeroed(); 10];
         (0..10).for_each(|i| {
-            tx[i].header.msg_id = rng.random();
+            tx[i].header.msg_id = autd3_core::link::MsgId::new(rng.random());
             tx[i].header.slot_2_offset = rng.random();
         });
         let msg: TxRawData = tx.as_slice().into();

--- a/autd3/src/async/controller/mod.rs
+++ b/autd3/src/async/controller/mod.rs
@@ -3,7 +3,7 @@ mod sender;
 
 use crate::{controller::SenderOption, error::AUTDError, gain::Null, modulation::Static};
 
-use autd3_core::link::AsyncLink;
+use autd3_core::link::{AsyncLink, MsgId};
 
 use autd3_driver::{
     datagram::{Clear, Datagram, FixedCompletionSteps, ForceFan, Silencer, Synchronize},
@@ -37,6 +37,7 @@ pub struct Controller<L: AsyncLink> {
     #[deref]
     #[deref_mut]
     geometry: Geometry,
+    msg_id: MsgId,
     tx_buf: Vec<TxMessage>,
     rx_buf: Vec<RxMessage>,
     /// The default sender option used for [`send`](Controller::send).
@@ -44,7 +45,7 @@ pub struct Controller<L: AsyncLink> {
 }
 
 impl<L: AsyncLink> Controller<L> {
-    /// Equivalent to [`Self::open_with_option`] with a timeout of [`DEFAULT_TIMEOUT`].
+    /// Equivalent to [`Self::open_with_option`] with default [`SenderOption`] and [`SpinSleeper`].
     pub async fn open<D: Into<Device>, F: IntoIterator<Item = D>>(
         devices: F,
         link: L,
@@ -75,6 +76,7 @@ impl<L: AsyncLink> Controller<L> {
             link,
             tx_buf: vec![TxMessage::new_zeroed(); geometry.len()], // Do not use `num_devices` here because the devices may be disabled.
             rx_buf: vec![RxMessage::new(0, 0); geometry.len()],
+            msg_id: MsgId::new(0),
             geometry,
             default_sender_option: option,
         }
@@ -85,6 +87,7 @@ impl<L: AsyncLink> Controller<L> {
     /// Returns the [`Sender`] to send data to the devices.
     pub fn sender<S: AsyncSleep>(&mut self, option: SenderOption, sleeper: S) -> Sender<'_, L, S> {
         Sender {
+            msg_id: &mut self.msg_id,
             link: &mut self.link,
             geometry: &mut self.geometry,
             tx: &mut self.tx_buf,
@@ -257,12 +260,14 @@ impl<L: AsyncLink + 'static> Controller<L> {
     /// Converts `Controller<L>` into a `Controller<Box<dyn Link>>`.
     pub fn into_boxed_link(self) -> Controller<Box<dyn AsyncLink>> {
         let cnt = std::mem::ManuallyDrop::new(self);
+        let msg_id = unsafe { std::ptr::read(&cnt.msg_id) };
         let link = unsafe { std::ptr::read(&cnt.link) };
         let geometry = unsafe { std::ptr::read(&cnt.geometry) };
         let tx_buf = unsafe { std::ptr::read(&cnt.tx_buf) };
         let rx_buf = unsafe { std::ptr::read(&cnt.rx_buf) };
         let default_sender_option = unsafe { std::ptr::read(&cnt.default_sender_option) };
         Controller {
+            msg_id,
             link: Box::new(link) as _,
             geometry,
             tx_buf,
@@ -278,12 +283,14 @@ impl<L: AsyncLink + 'static> Controller<L> {
     /// This function must be used only when converting an instance created by [`Controller::into_boxed_link`] back to the original [`Controller<L>`].
     pub unsafe fn from_boxed_link(cnt: Controller<Box<dyn AsyncLink>>) -> Controller<L> {
         let cnt = std::mem::ManuallyDrop::new(cnt);
+        let msg_id = unsafe { std::ptr::read(&cnt.msg_id) };
         let link = unsafe { std::ptr::read(&cnt.link) };
         let geometry = unsafe { std::ptr::read(&cnt.geometry) };
         let tx_buf = unsafe { std::ptr::read(&cnt.tx_buf) };
         let rx_buf = unsafe { std::ptr::read(&cnt.rx_buf) };
         let default_sender_option = unsafe { std::ptr::read(&cnt.default_sender_option) };
         Controller {
+            msg_id,
             link: unsafe { *Box::from_raw(Box::into_raw(link) as *mut L) },
             geometry,
             tx_buf,

--- a/autd3/src/async/controller/mod.rs
+++ b/autd3/src/async/controller/mod.rs
@@ -44,7 +44,7 @@ pub struct Controller<L: AsyncLink> {
 }
 
 impl<L: AsyncLink> Controller<L> {
-    /// Equivalent to [`Self::open_with_option`] with default [`SenderOption`] and [`SpinSleeper`].
+    /// Equivalent to [`Self::open_with_option`] with default [`SenderOption`] and [`AsyncSleeper`].
     pub async fn open<D: Into<Device>, F: IntoIterator<Item = D>>(
         devices: F,
         link: L,

--- a/autd3/src/async/controller/sender/mod.rs
+++ b/autd3/src/async/controller/sender/mod.rs
@@ -27,7 +27,7 @@ pub struct Sender<'a, L: AsyncLink, S: AsyncSleep> {
     pub(crate) msg_id: &'a mut MsgId,
     pub(crate) link: &'a mut L,
     pub(crate) geometry: &'a mut Geometry,
-    pub(crate) tx: &'a mut [TxMessage],
+    pub(crate) sent_flags: &'a mut [bool],
     pub(crate) rx: &'a mut [RxMessage],
     pub(crate) option: SenderOption,
     pub(crate) sleeper: S,
@@ -84,16 +84,19 @@ impl<L: AsyncLink, S: AsyncSleep> Sender<'_, L, S> {
         // For example, if the `send_interval` is 1ms and it takes 1.5ms to transmit due to some reason, the next transmission will be performed not 1ms later but 0.5ms later.
         let mut send_timing = Instant::now();
         loop {
+            let mut tx = self.link.alloc_tx_buffer().await;
+
             self.msg_id.increment();
             OperationHandler::pack(
                 *self.msg_id,
                 &mut operations,
                 self.geometry,
-                self.tx,
+                self.sent_flags,
+                &mut tx,
                 parallel,
             )?;
 
-            self.send_receive(timeout).await?;
+            self.send_receive(tx, timeout).await?;
 
             if OperationHandler::is_done(&operations) {
                 return Ok(());
@@ -104,13 +107,17 @@ impl<L: AsyncLink, S: AsyncSleep> Sender<'_, L, S> {
         }
     }
 
-    async fn send_receive(&mut self, timeout: Duration) -> Result<(), AUTDDriverError> {
+    async fn send_receive(
+        &mut self,
+        tx: Vec<TxMessage>,
+        timeout: Duration,
+    ) -> Result<(), AUTDDriverError> {
         if !self.link.is_open() {
             return Err(AUTDDriverError::LinkClosed);
         }
 
-        tracing::trace!("send: {}", self.tx.iter().join(", "));
-        self.link.send(self.tx).await?;
+        tracing::trace!("send: {}", tx.iter().join(", "));
+        self.link.send(tx).await?;
         self.wait_msg_processed(timeout).await
     }
 
@@ -124,9 +131,9 @@ impl<L: AsyncLink, S: AsyncSleep> Sender<'_, L, S> {
             self.link.receive(self.rx).await?;
             tracing::trace!("recv: {}", self.rx.iter().join(", "));
 
-            if check_if_msg_is_processed(self.tx, self.rx)
-                .zip(self.geometry.iter())
-                .filter_map(|(r, dev)| dev.enable.then_some(r))
+            if check_if_msg_is_processed(*self.msg_id, self.rx)
+                .zip(self.sent_flags.iter())
+                .filter_map(|(r, sent)| sent.then_some(r))
                 .all(std::convert::identity)
             {
                 return Ok(());
@@ -155,7 +162,7 @@ impl<L: AsyncLink, S: AsyncSleep> Sender<'_, L, S> {
 
 #[cfg(test)]
 mod tests {
-    use autd3_core::link::LinkError;
+    use autd3_core::link::{LinkError, TxBufferPoolSync};
     use spin_sleep::SpinSleeper;
     use zerocopy::FromZeros;
 
@@ -174,15 +181,14 @@ mod tests {
         pub send_cnt: usize,
         pub recv_cnt: usize,
         pub down: bool,
+        pub buffer_pool: TxBufferPoolSync,
     }
 
     #[cfg_attr(feature = "async-trait", autd3_core::async_trait)]
     impl AsyncLink for MockAsyncLink {
-        async fn open(&mut self, _: &Geometry) -> Result<(), LinkError> {
+        async fn open(&mut self, geometry: &Geometry) -> Result<(), LinkError> {
             self.is_open = true;
-            self.send_cnt = 0;
-            self.recv_cnt = 0;
-            self.down = false;
+            self.buffer_pool.init(geometry);
             Ok(())
         }
 
@@ -191,10 +197,15 @@ mod tests {
             Ok(())
         }
 
-        async fn send(&mut self, _: &[TxMessage]) -> Result<(), LinkError> {
+        async fn alloc_tx_buffer(&mut self) -> Vec<TxMessage> {
+            self.buffer_pool.borrow()
+        }
+
+        async fn send(&mut self, tx: Vec<TxMessage>) -> Result<(), LinkError> {
             if !self.down {
                 self.send_cnt += 1;
             }
+            self.buffer_pool.return_buffer(tx);
             Ok(())
         }
 
@@ -238,7 +249,7 @@ mod tests {
     async fn test_send_receive(#[case] sleeper: impl AsyncSleep) {
         let mut link = MockAsyncLink::default();
         let mut geometry = create_geometry(1);
-        let mut tx = vec![];
+        let mut sent_flags = vec![false; 1];
         let mut rx = Vec::new();
         let mut msg_id = MsgId::new(0);
 
@@ -247,7 +258,7 @@ mod tests {
             msg_id: &mut msg_id,
             link: &mut link,
             geometry: &mut geometry,
-            tx: &mut tx,
+            sent_flags: &mut sent_flags,
             rx: &mut rx,
             option: SenderOption {
                 send_interval: Duration::from_millis(1),
@@ -258,13 +269,25 @@ mod tests {
             sleeper,
         };
 
-        assert_eq!(Ok(()), sender.send_receive(Duration::ZERO).await);
-        assert_eq!(Ok(()), sender.send_receive(Duration::from_millis(1)).await);
+        assert_eq!(
+            Ok(()),
+            sender
+                .send_receive(vec![TxMessage::new_zeroed()], Duration::ZERO)
+                .await
+        );
+        assert_eq!(
+            Ok(()),
+            sender
+                .send_receive(vec![TxMessage::new_zeroed()], Duration::from_millis(1))
+                .await
+        );
 
         sender.link.is_open = false;
         assert_eq!(
             Err(AUTDDriverError::LinkClosed),
-            sender.send_receive(Duration::ZERO).await,
+            sender
+                .send_receive(vec![TxMessage::new_zeroed()], Duration::ZERO)
+                .await,
         );
     }
 
@@ -277,17 +300,16 @@ mod tests {
     async fn test_wait_msg_processed(#[case] sleeper: impl AsyncSleep) {
         let mut link = MockAsyncLink::default();
         let mut geometry = create_geometry(1);
-        let mut tx = vec![TxMessage::new_zeroed(); 1];
-        tx[0].header.msg_id = MsgId::new(2);
+        let mut sent_flags = vec![true; 1];
         let mut rx = vec![RxMessage::new(0, 0)];
-        let mut msg_id = MsgId::new(0);
+        let mut msg_id = MsgId::new(1);
 
         assert!(link.open(&geometry).await.is_ok());
         let mut sender = Sender {
             msg_id: &mut msg_id,
             link: &mut link,
             geometry: &mut geometry,
-            tx: &mut tx,
+            sent_flags: &mut sent_flags,
             rx: &mut rx,
             option: SenderOption {
                 send_interval: Duration::from_millis(1),
@@ -325,7 +347,7 @@ mod tests {
 
         sender.link.down = false;
         sender.link.recv_cnt = 0;
-        sender.tx[0].header.msg_id = MsgId::new(20);
+        *sender.msg_id = MsgId::new(20);
         assert_eq!(
             Err(AUTDDriverError::Link(LinkError::new("too many"))),
             sender.wait_msg_processed(Duration::from_secs(10)).await

--- a/autd3/src/controller/mod.rs
+++ b/autd3/src/controller/mod.rs
@@ -8,7 +8,7 @@ use autd3_driver::{
     datagram::{Clear, Datagram, FixedCompletionSteps, ForceFan, Silencer, Synchronize},
     error::AUTDDriverError,
     firmware::{
-        cpu::{RxMessage, TxMessage, check_if_msg_is_processed},
+        cpu::{RxMessage, check_if_msg_is_processed},
         fpga::FPGAState,
         operation::{FirmwareVersionType, Operation, OperationGenerator},
         version::FirmwareVersion,
@@ -25,7 +25,6 @@ pub use sender::{
 use derive_more::{Deref, DerefMut};
 use getset::{Getters, MutGetters};
 use tracing;
-use zerocopy::FromZeros;
 
 /// A controller for the AUTD devices.
 ///
@@ -41,7 +40,7 @@ pub struct Controller<L: Link> {
     #[deref_mut]
     geometry: Geometry,
     msg_id: MsgId,
-    tx_buf: Vec<TxMessage>,
+    sent_flags: Vec<bool>,
     rx_buf: Vec<RxMessage>,
     /// The default sender option used for [`send`](Controller::send).
     pub default_sender_option: SenderOption,
@@ -77,7 +76,8 @@ impl<L: Link> Controller<L> {
         Controller {
             link,
             msg_id: MsgId::new(0),
-            tx_buf: vec![TxMessage::new_zeroed(); geometry.len()], // Do not use `num_devices` here because the devices may be disabled.
+            // Do not use `num_devices` here because the devices may be disabled.
+            sent_flags: vec![false; geometry.len()],
             rx_buf: vec![RxMessage::new(0, 0); geometry.len()],
             geometry,
             default_sender_option: option,
@@ -91,7 +91,7 @@ impl<L: Link> Controller<L> {
             msg_id: &mut self.msg_id,
             link: &mut self.link,
             geometry: &mut self.geometry,
-            tx: &mut self.tx_buf,
+            sent_flags: &mut self.sent_flags,
             rx: &mut self.rx_buf,
             option,
             sleeper,
@@ -167,7 +167,7 @@ impl<L: Link> Controller<L> {
         self.send(ty).map_err(|e| {
             tracing::error!("Fetch firmware info failed: {:?}", e);
             AUTDError::ReadFirmwareVersionFailed(
-                check_if_msg_is_processed(&self.tx_buf, &self.rx_buf).collect(),
+                check_if_msg_is_processed(self.msg_id, &self.rx_buf).collect(),
             )
         })?;
         Ok(self.rx_buf.iter().map(|rx| rx.data()).collect())
@@ -259,14 +259,14 @@ impl<L: Link + 'static> Controller<L> {
         let msg_id = unsafe { std::ptr::read(&cnt.msg_id) };
         let link = unsafe { std::ptr::read(&cnt.link) };
         let geometry = unsafe { std::ptr::read(&cnt.geometry) };
-        let tx_buf = unsafe { std::ptr::read(&cnt.tx_buf) };
+        let sent_flags = unsafe { std::ptr::read(&cnt.sent_flags) };
         let rx_buf = unsafe { std::ptr::read(&cnt.rx_buf) };
         let default_sender_option = unsafe { std::ptr::read(&cnt.default_sender_option) };
         Controller {
             msg_id,
             link: Box::new(link) as _,
             geometry,
-            tx_buf,
+            sent_flags,
             rx_buf,
             default_sender_option,
         }
@@ -282,14 +282,14 @@ impl<L: Link + 'static> Controller<L> {
         let msg_id = unsafe { std::ptr::read(&cnt.msg_id) };
         let link = unsafe { std::ptr::read(&cnt.link) };
         let geometry = unsafe { std::ptr::read(&cnt.geometry) };
-        let tx_buf = unsafe { std::ptr::read(&cnt.tx_buf) };
+        let sent_flags = unsafe { std::ptr::read(&cnt.sent_flags) };
         let rx_buf = unsafe { std::ptr::read(&cnt.rx_buf) };
         let default_sender_option = unsafe { std::ptr::read(&cnt.default_sender_option) };
         Controller {
             msg_id,
             link: unsafe { *Box::from_raw(Box::into_raw(link) as *mut L) },
             geometry,
-            tx_buf,
+            sent_flags,
             rx_buf,
             default_sender_option,
         }

--- a/autd3/src/controller/sender/mod.rs
+++ b/autd3/src/controller/sender/mod.rs
@@ -84,7 +84,7 @@ pub struct Sender<'a, L: Link, S: Sleep> {
     pub(crate) msg_id: &'a mut MsgId,
     pub(crate) link: &'a mut L,
     pub(crate) geometry: &'a mut Geometry,
-    pub(crate) tx: &'a mut [TxMessage],
+    pub(crate) sent_flags: &'a mut [bool],
     pub(crate) rx: &'a mut [RxMessage],
     pub(crate) option: SenderOption,
     pub(crate) sleeper: S,
@@ -140,16 +140,19 @@ impl<L: Link, S: Sleep> Sender<'_, L, S> {
         // For example, if the `send_interval` is 1ms and it takes 1.5ms to transmit due to some reason, the next transmission will be performed not 1ms later but 0.5ms later.
         let mut send_timing = Instant::now();
         loop {
+            let mut tx = self.link.alloc_tx_buffer();
+
             self.msg_id.increment();
             OperationHandler::pack(
                 *self.msg_id,
                 &mut operations,
                 self.geometry,
-                self.tx,
+                self.sent_flags,
+                &mut tx,
                 parallel,
             )?;
 
-            self.send_receive(timeout)?;
+            self.send_receive(tx, timeout)?;
 
             if OperationHandler::is_done(&operations) {
                 return Ok(());
@@ -160,13 +163,17 @@ impl<L: Link, S: Sleep> Sender<'_, L, S> {
         }
     }
 
-    fn send_receive(&mut self, timeout: Duration) -> Result<(), AUTDDriverError> {
+    fn send_receive(
+        &mut self,
+        tx: Vec<TxMessage>,
+        timeout: Duration,
+    ) -> Result<(), AUTDDriverError> {
         if !self.link.is_open() {
             return Err(AUTDDriverError::LinkClosed);
         }
 
-        tracing::trace!("send: {}", self.tx.iter().join(", "));
-        self.link.send(self.tx)?;
+        tracing::trace!("send: {}", tx.iter().join(", "));
+        self.link.send(tx)?;
         self.wait_msg_processed(timeout)
     }
 
@@ -180,9 +187,9 @@ impl<L: Link, S: Sleep> Sender<'_, L, S> {
             self.link.receive(self.rx)?;
             tracing::trace!("recv: {}", self.rx.iter().join(", "));
 
-            if check_if_msg_is_processed(self.tx, self.rx)
-                .zip(self.geometry.iter())
-                .filter_map(|(r, dev)| dev.enable.then_some(r))
+            if check_if_msg_is_processed(*self.msg_id, self.rx)
+                .zip(self.sent_flags.iter())
+                .filter_map(|(r, sent)| sent.then_some(r))
                 .all(std::convert::identity)
             {
                 return Ok(());
@@ -211,7 +218,7 @@ impl<L: Link, S: Sleep> Sender<'_, L, S> {
 
 #[cfg(test)]
 mod tests {
-    use autd3_core::link::LinkError;
+    use autd3_core::link::{LinkError, TxBufferPoolSync};
     use zerocopy::FromZeros;
 
     #[cfg(target_os = "windows")]
@@ -249,11 +256,13 @@ mod tests {
         pub send_cnt: usize,
         pub recv_cnt: usize,
         pub down: bool,
+        pub buffer_pool: TxBufferPoolSync,
     }
 
     impl Link for MockLink {
-        fn open(&mut self, _: &Geometry) -> Result<(), LinkError> {
+        fn open(&mut self, geometry: &Geometry) -> Result<(), LinkError> {
             self.is_open = true;
+            self.buffer_pool.init(geometry);
             Ok(())
         }
 
@@ -262,10 +271,15 @@ mod tests {
             Ok(())
         }
 
-        fn send(&mut self, _: &[TxMessage]) -> Result<(), LinkError> {
+        fn alloc_tx_buffer(&mut self) -> Vec<TxMessage> {
+            self.buffer_pool.borrow()
+        }
+
+        fn send(&mut self, tx: Vec<TxMessage>) -> Result<(), LinkError> {
             if !self.down {
                 self.send_cnt += 1;
             }
+            self.buffer_pool.return_buffer(tx);
             Ok(())
         }
 
@@ -310,7 +324,7 @@ mod tests {
     fn test_send_receive(#[case] sleeper: impl Sleep) {
         let mut link = MockLink::default();
         let mut geometry = create_geometry(1);
-        let mut tx = vec![];
+        let mut sent_flags = vec![false; 1];
         let mut rx = Vec::new();
         let mut msg_id = MsgId::new(0);
 
@@ -319,7 +333,7 @@ mod tests {
             msg_id: &mut msg_id,
             link: &mut link,
             geometry: &mut geometry,
-            tx: &mut tx,
+            sent_flags: &mut sent_flags,
             rx: &mut rx,
             option: SenderOption {
                 send_interval: Duration::from_millis(1),
@@ -330,12 +344,18 @@ mod tests {
             sleeper,
         };
 
-        assert_eq!(Ok(()), sender.send_receive(Duration::ZERO));
-        assert_eq!(Ok(()), sender.send_receive(Duration::from_millis(1)));
+        assert_eq!(
+            Ok(()),
+            sender.send_receive(vec![TxMessage::new_zeroed()], Duration::ZERO)
+        );
+        assert_eq!(
+            Ok(()),
+            sender.send_receive(vec![TxMessage::new_zeroed()], Duration::from_millis(1))
+        );
 
         sender.link.is_open = false;
         assert_eq!(
-            sender.send_receive(Duration::ZERO),
+            sender.send_receive(vec![TxMessage::new_zeroed()], Duration::ZERO),
             Err(AUTDDriverError::LinkClosed)
         );
     }
@@ -348,17 +368,16 @@ mod tests {
     fn test_wait_msg_processed(#[case] sleeper: impl Sleep) {
         let mut link = MockLink::default();
         let mut geometry = create_geometry(1);
-        let mut tx = vec![TxMessage::new_zeroed(); 1];
-        tx[0].header.msg_id = MsgId::new(2);
+        let mut sent_flags = vec![true; 1];
         let mut rx = vec![RxMessage::new(0, 0)];
-        let mut msg_id = MsgId::new(0);
+        let mut msg_id = MsgId::new(1);
 
         assert!(link.open(&geometry).is_ok());
         let mut sender = Sender {
             msg_id: &mut msg_id,
             link: &mut link,
             geometry: &mut geometry,
-            tx: &mut tx,
+            sent_flags: &mut sent_flags,
             rx: &mut rx,
             option: SenderOption {
                 send_interval: Duration::from_millis(1),
@@ -393,7 +412,7 @@ mod tests {
 
         sender.link.down = false;
         sender.link.recv_cnt = 0;
-        sender.tx[0].header.msg_id = MsgId::new(20);
+        *sender.msg_id = MsgId::new(20);
         assert_eq!(
             Err(AUTDDriverError::Link(LinkError::new("too many"))),
             sender.wait_msg_processed(Duration::from_secs(10))

--- a/autd3/src/controller/sender/mod.rs
+++ b/autd3/src/controller/sender/mod.rs
@@ -219,7 +219,6 @@ impl<L: Link, S: Sleep> Sender<'_, L, S> {
 #[cfg(test)]
 mod tests {
     use autd3_core::link::{LinkError, TxBufferPoolSync};
-    use zerocopy::FromZeros;
 
     #[cfg(target_os = "windows")]
     use crate::controller::sender::WaitableSleeper;
@@ -344,18 +343,16 @@ mod tests {
             sleeper,
         };
 
-        assert_eq!(
-            Ok(()),
-            sender.send_receive(vec![TxMessage::new_zeroed()], Duration::ZERO)
-        );
-        assert_eq!(
-            Ok(()),
-            sender.send_receive(vec![TxMessage::new_zeroed()], Duration::from_millis(1))
-        );
+        let tx = sender.link.alloc_tx_buffer();
+        assert_eq!(Ok(()), sender.send_receive(tx, Duration::ZERO));
+
+        let tx = sender.link.alloc_tx_buffer();
+        assert_eq!(Ok(()), sender.send_receive(tx, Duration::from_millis(1)));
 
         sender.link.is_open = false;
+        let tx = sender.link.alloc_tx_buffer();
         assert_eq!(
-            sender.send_receive(vec![TxMessage::new_zeroed()], Duration::ZERO),
+            sender.send_receive(tx, Duration::ZERO),
             Err(AUTDDriverError::LinkClosed)
         );
     }

--- a/autd3/src/link/audit.rs
+++ b/autd3/src/link/audit.rs
@@ -1,6 +1,6 @@
 use autd3_core::{
     geometry::Geometry,
-    link::{Link, LinkError, MsgId},
+    link::{Link, LinkError, MsgId, TxBufferPoolSync},
 };
 
 use autd3_driver::firmware::cpu::{RxMessage, TxMessage};
@@ -25,6 +25,7 @@ pub struct Audit {
     #[deref_mut]
     cpus: Vec<CPUEmulator>,
     broken: bool,
+    buffer_pool: TxBufferPoolSync,
 }
 
 impl Audit {
@@ -34,6 +35,7 @@ impl Audit {
             is_open: false,
             cpus: Vec::new(),
             broken: false,
+            buffer_pool: TxBufferPoolSync::new(),
         }
     }
 
@@ -68,6 +70,7 @@ impl Link for Audit {
             })
             .collect();
         self.broken = self.option.broken;
+        self.buffer_pool.init(geometry);
         Ok(())
     }
 
@@ -76,13 +79,21 @@ impl Link for Audit {
         Ok(())
     }
 
-    fn send(&mut self, tx: &[TxMessage]) -> Result<(), LinkError> {
+    fn alloc_tx_buffer(&mut self) -> Vec<TxMessage> {
+        self.buffer_pool.borrow()
+    }
+
+    fn send(&mut self, tx: Vec<TxMessage>) -> Result<(), LinkError> {
         if self.broken {
             return Err(LinkError::new("broken"));
         }
+
         self.cpus.iter_mut().for_each(|cpu| {
-            cpu.send(tx);
+            cpu.send(&tx);
         });
+
+        self.buffer_pool.return_buffer(tx);
+
         Ok(())
     }
 
@@ -118,7 +129,11 @@ impl AsyncLink for Audit {
         <Self as Link>::close(self)
     }
 
-    async fn send(&mut self, tx: &[TxMessage]) -> Result<(), LinkError> {
+    async fn alloc_tx_buffer(&mut self) -> Vec<TxMessage> {
+        <Self as Link>::alloc_tx_buffer(self)
+    }
+
+    async fn send(&mut self, tx: Vec<TxMessage>) -> Result<(), LinkError> {
         <Self as Link>::send(self, tx)
     }
 

--- a/autd3/src/link/audit.rs
+++ b/autd3/src/link/audit.rs
@@ -79,8 +79,8 @@ impl Link for Audit {
         Ok(())
     }
 
-    fn alloc_tx_buffer(&mut self) -> Vec<TxMessage> {
-        self.buffer_pool.borrow()
+    fn alloc_tx_buffer(&mut self) -> Result<Vec<TxMessage>, LinkError> {
+        Ok(self.buffer_pool.borrow())
     }
 
     fn send(&mut self, tx: Vec<TxMessage>) -> Result<(), LinkError> {
@@ -129,7 +129,7 @@ impl AsyncLink for Audit {
         <Self as Link>::close(self)
     }
 
-    async fn alloc_tx_buffer(&mut self) -> Vec<TxMessage> {
+    async fn alloc_tx_buffer(&mut self) -> Result<Vec<TxMessage>, LinkError> {
         <Self as Link>::alloc_tx_buffer(self)
     }
 

--- a/autd3/src/link/audit.rs
+++ b/autd3/src/link/audit.rs
@@ -1,6 +1,6 @@
 use autd3_core::{
     geometry::Geometry,
-    link::{Link, LinkError},
+    link::{Link, LinkError, MsgId},
 };
 
 use autd3_driver::firmware::cpu::{RxMessage, TxMessage};
@@ -11,7 +11,7 @@ use derive_more::{Deref, DerefMut};
 #[derive(Default)]
 #[doc(hidden)]
 pub struct AuditOption {
-    pub initial_msg_id: Option<u8>,
+    pub initial_msg_id: Option<MsgId>,
     pub initial_phase_corr: Option<u8>,
     pub broken: bool,
 }

--- a/autd3/src/link/nop.rs
+++ b/autd3/src/link/nop.rs
@@ -44,8 +44,8 @@ impl Link for Nop {
         Ok(())
     }
 
-    fn alloc_tx_buffer(&mut self) -> Vec<TxMessage> {
-        self.buffer_pool.borrow()
+    fn alloc_tx_buffer(&mut self) -> Result<Vec<TxMessage>, LinkError> {
+        Ok(self.buffer_pool.borrow())
     }
 
     fn send(&mut self, tx: Vec<TxMessage>) -> Result<(), LinkError> {
@@ -84,7 +84,7 @@ impl AsyncLink for Nop {
         <Self as Link>::close(self)
     }
 
-    async fn alloc_tx_buffer(&mut self) -> Vec<TxMessage> {
+    async fn alloc_tx_buffer(&mut self) -> Result<Vec<TxMessage>, LinkError> {
         <Self as Link>::alloc_tx_buffer(self)
     }
 

--- a/autd3/tests/async/mod.rs
+++ b/autd3/tests/async/mod.rs
@@ -4,6 +4,7 @@ use autd3::{
     link::{Audit, AuditOption},
     prelude::{AUTD3, AUTDDriverError},
 };
+use autd3_core::link::MsgId;
 
 mod link;
 
@@ -12,7 +13,7 @@ async fn initial_msg_id() -> anyhow::Result<()> {
     let cnt = Controller::open(
         [AUTD3::default()],
         Audit::new(AuditOption {
-            initial_msg_id: Some(0x01),
+            initial_msg_id: Some(MsgId::new(0x01)),
             initial_phase_corr: Some(0xFF),
             ..Default::default()
         }),

--- a/autd3/tests/sync/mod.rs
+++ b/autd3/tests/sync/mod.rs
@@ -4,6 +4,7 @@ use autd3::{
     link::{Audit, AuditOption},
     prelude::{AUTD3, AUTDDriverError},
 };
+use autd3_core::link::MsgId;
 
 mod datagram;
 mod link;
@@ -13,7 +14,7 @@ fn initial_msg_id() -> anyhow::Result<()> {
     let cnt = Controller::open(
         [AUTD3::default()],
         Audit::new(AuditOption {
-            initial_msg_id: Some(0x01),
+            initial_msg_id: Some(MsgId::new(0x01)),
             initial_phase_corr: Some(0xFF),
             ..Default::default()
         }),


### PR DESCRIPTION
- **add `MsgId` struct and transfer its management to `Controller`**
- **transfer management of tx buffers from `Controller` to `Link`**
