### PR TITLE
fix for rust 1.87.0

### DIFF
--- a/autd3-modulation-audio-file/src/error.rs
+++ b/autd3-modulation-audio-file/src/error.rs
@@ -32,7 +32,7 @@ mod tests {
 
     #[test]
     fn test_audio_file_error() {
-        let e = AudioFileError::Io(std::io::Error::new(std::io::ErrorKind::Other, "test"));
+        let e = AudioFileError::Io(std::io::Error::other("test"));
         assert_eq!(e.to_string(), "test");
         assert_eq!(
             format!("{:?}", e),

--- a/autd3-protobuf/src/lightweight/server/gain.rs
+++ b/autd3-protobuf/src/lightweight/server/gain.rs
@@ -3,6 +3,7 @@ use autd3::gain::*;
 use autd3_driver::datagram::BoxedGain;
 use autd3_gain_holo::*;
 
+#[allow(clippy::result_large_err)]
 pub(crate) fn gain_into_boxed(msg: crate::pb::Gain) -> Result<BoxedGain, AUTDProtoBufError> {
     let gain = msg.gain.ok_or(AUTDProtoBufError::DataParseError)?;
     match gain {

--- a/autd3-protobuf/src/lightweight/server/mod.rs
+++ b/autd3-protobuf/src/lightweight/server/mod.rs
@@ -41,6 +41,7 @@ where
     }
 }
 
+#[allow(clippy::result_large_err)]
 fn into_boxed_datagram(datagram: datagram::Datagram) -> Result<BoxedDatagram, AUTDProtoBufError> {
     use autd3_driver::datagram::*;
     match datagram {
@@ -290,6 +291,7 @@ fn into_boxed_datagram(datagram: datagram::Datagram) -> Result<BoxedDatagram, AU
     }
 }
 
+#[allow(clippy::result_large_err)]
 fn into_datagram_tuple(
     tuple: DatagramTuple,
 ) -> Result<tuple::BoxedDatagramTuple, AUTDProtoBufError> {

--- a/autd3-protobuf/src/lightweight/server/modulation.rs
+++ b/autd3-protobuf/src/lightweight/server/modulation.rs
@@ -3,6 +3,7 @@ use autd3::modulation::*;
 use autd3_core::defined::Freq;
 use autd3_driver::datagram::BoxedModulation;
 
+#[allow(clippy::result_large_err)]
 pub(crate) fn modulation_into_boxed(
     msg: crate::pb::Modulation,
 ) -> Result<BoxedModulation, AUTDProtoBufError> {

--- a/autd3-protobuf/src/traits/mod.rs
+++ b/autd3-protobuf/src/traits/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod driver;
 mod holo;
 
 #[cfg(feature = "lightweight")]
+#[allow(clippy::result_large_err)]
 pub trait DatagramLightweight {
     fn into_datagram_lightweight(
         self,
@@ -14,6 +15,7 @@ pub trait DatagramLightweight {
     ) -> Result<crate::Datagram, AUTDProtoBufError>;
 }
 
+#[allow(clippy::result_large_err)]
 pub trait FromMessage<T>
 where
     Self: Sized,


### PR DESCRIPTION
- **add `#[allow(clippy::result_large_err)]`  to `Result<T, AUTDProtoBufError>`**
- **simplify error creation in test for `AudioFileError`**
